### PR TITLE
BUG: wrong forward daily returns

### DIFF
--- a/alphalens/tests/test_utils.py
+++ b/alphalens/tests/test_utils.py
@@ -46,6 +46,6 @@ class UtilsTestCase(TestCase):
                                      names=['date', 'asset'])
         expected = DataFrame(index=ix, columns=[1, 2])
         expected[1] = [0., 1., 1., -0.5, nan, nan]
-        expected[2] = [0.5, 0., nan, nan, nan, nan]
+        expected[2] = [0.41421356237309515, 0., nan, nan, nan, nan]
 
         assert_frame_equal(fp, expected)

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -54,7 +54,7 @@ def compute_forward_returns(prices, days=(1, 5, 10), filter_zscore=None):
             mask = abs(delta - delta.mean()) > (filter_zscore * delta.std())
             delta[mask] = np.nan
 
-        forward_returns[day] = delta.stack() / day
+        forward_returns[day] = delta.stack().add(1).pow(1./day).sub(1)
 
     forward_returns.index.rename(['date', 'asset'], inplace=True)
 


### PR DESCRIPTION
current implementation calculates daily returns as forward returns divided
by number of days:
daily_returns = fwd_ret / days

This patch calculate the daily returns as the value the returns would have
had every single day for 'forward' days if they had grown at a steady rate
that is:
daily_returns = (fwd_ret+1)**(1./days) - 1