### PR TITLE
Making forward returns "demeaning" optional

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -261,9 +261,10 @@ def quantize_factor(factor, quantiles=5, by_group=False):
 def mean_return_by_quantile(quantized_factor,
                             forward_returns,
                             by_time=None,
-                            by_group=False):
+                            by_group=False,
+                            demeaned=True):
     """
-    Computes mean demeaned returns for factor quantiles across
+    Computes mean returns for factor quantiles across
     provided forward returns columns.
 
     Parameters
@@ -281,6 +282,8 @@ def mean_return_by_quantile(quantized_factor,
     by_group : bool
         If True, compute quantile bucket returns separately for each group.
         Returns demeaning will occur on the group level.
+    demeaned : bool
+        Compute demeaned mean returns (long short portfolio)
 
     Returns
     -------
@@ -290,8 +293,11 @@ def mean_return_by_quantile(quantized_factor,
         Standard error of returns by specified quantile.
     """
 
-    demeaned_fr = utils.demean_forward_returns(forward_returns,
-                                               by_group=by_group)
+    if demeaned	:
+        demeaned_fr = utils.demean_forward_returns(forward_returns,
+                                                   by_group=by_group)
+    else:
+        demeaned_fr = forward_returns.copy()
 
     quantized_factor = quantized_factor.copy()
     quantized_factor.name = 'quantile'

--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -293,7 +293,7 @@ def mean_return_by_quantile(quantized_factor,
         Standard error of returns by specified quantile.
     """
 
-    if demeaned	:
+    if demeaned:
         demeaned_fr = utils.demean_forward_returns(forward_returns,
                                                    by_group=by_group)
     else:

--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -294,15 +294,15 @@ def mean_return_by_quantile(quantized_factor,
     """
 
     if demeaned:
-        demeaned_fr = utils.demean_forward_returns(forward_returns,
+        adjusted_fr = utils.demean_forward_returns(forward_returns,
                                                    by_group=by_group)
     else:
-        demeaned_fr = forward_returns.copy()
+        adjusted_fr = forward_returns.copy()
 
     quantized_factor = quantized_factor.copy()
     quantized_factor.name = 'quantile'
     forward_returns_quantile = (pd.DataFrame(quantized_factor)
-                                .merge(demeaned_fr,
+                                .merge(adjusted_fr,
                                        how='left',
                                        left_index=True,
                                        right_index=True)

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -29,7 +29,8 @@ def create_factor_tear_sheet(factor,
                              periods=(1, 5, 10),
                              quantiles=5,
                              filter_zscore=10,
-                             groupby_labels=None):
+                             groupby_labels=None,
+                             long_short=True):
     """
     Creates a full tear sheet for analysis and evaluating single
     return predicting (alpha) factor.
@@ -82,6 +83,8 @@ def create_factor_tear_sheet(factor,
     groupby_labels : dict
         A dictionary keyed by group code with values corresponding
         to the display name for each group.
+    long_short : bool
+        Should this computation happen on a long short portfolio?
     """
 
     periods = list(periods)
@@ -106,7 +109,7 @@ def create_factor_tear_sheet(factor,
                                                         forward_returns,
                                                         by_time="M")
 
-    factor_returns = perf.factor_returns(factor, forward_returns)
+    factor_returns = perf.factor_returns(factor, forward_returns, long_short)
 
     alpha_beta = perf.factor_alpha_beta(factor,
                                         forward_returns,
@@ -118,12 +121,14 @@ def create_factor_tear_sheet(factor,
 
     mean_ret_quantile, std_quantile = perf.mean_return_by_quantile(quantile_factor,
                                                                    forward_returns,
-                                                                   by_group=False)
+                                                                   by_group=False,
+                                                                   demeaned=long_short)
 
     mean_ret_quant_daily, std_quant_daily = perf.mean_return_by_quantile(quantile_factor,
                                                                          forward_returns,
                                                                          by_time='D',
-                                                                         by_group=False)
+                                                                         by_group=False,
+                                                                         demeaned=long_short)
 
     mean_ret_spread_quant, std_spread_quant = perf.compute_mean_returns_spread(mean_ret_quant_daily,
                                                                                quantiles,
@@ -237,7 +242,8 @@ def create_factor_tear_sheet(factor,
 
         mean_return_quantile_group, mean_return_quantile_group_std_err = perf.mean_return_by_quantile(quantile_factor,
                                                                                                       forward_returns,
-                                                                                                      by_group=True)
+                                                                                                      by_group=True,
+                                                                                                      demeaned=True)
 
         num_groups = len(ic_by_group.index.get_level_values('group').unique())
         rows_when_2_wide = (((num_groups - 1) // 2) + 1)


### PR DESCRIPTION
The forward returns used in the variour retuns related plots are converted
to returns relative to mean (demeaned). it implies a long short portfolio
and that is not always the case. This commit make the demeaning optional

see #72