### PR TITLE
Fixing cases when ValueError from alphalens.tears.create_factor_tear_sheet

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -247,7 +247,16 @@ def quantize_factor(factor, quantiles=5, by_group=False):
     """
 
     def quantile_calc(x, quantiles):
-        return pd.qcut(x, quantiles, labels=False) + 1
+        try:
+            return pd.qcut(x, quantiles, labels=False) + 1
+        except ValueError as e:
+            # This is the case when we have quantiles of the same
+            # ValueError: Bin edges must be unique: array([1, 1, 1, 1, 1])
+            # Some solution discussed at:
+            # - http://stackoverflow.com/questions/20158597/how-to-qcut-with-non-unique-bin-edges
+            # - https://github.com/pydata/pandas/issues/7751#issue-37814702
+            # But there's nothing satisfying yet
+            raise e
 
     grouper = ['date', 'group'] if by_group else ['date']
 

--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -252,10 +252,8 @@ def quantize_factor(factor, quantiles=5, by_group=False):
         except ValueError as e:
             # This is the case when we have quantiles of the same
             # ValueError: Bin edges must be unique: array([1, 1, 1, 1, 1])
-            # Some solution discussed at:
-            # - http://stackoverflow.com/questions/20158597/how-to-qcut-with-non-unique-bin-edges
-            # - https://github.com/pydata/pandas/issues/7751#issue-37814702
-            # But there's nothing satisfying yet
+            if x.nunique() == 1:
+                return x.rank().astype('int')
             raise e
 
     grouper = ['date', 'group'] if by_group else ['date']

--- a/alphalens/tests/test_performance.py
+++ b/alphalens/tests/test_performance.py
@@ -141,10 +141,12 @@ class PerformanceTestCase(TestCase):
                             [1, 1, 2, 2, 2, 2, 1, 1]),
                            (factor, 2, True,
                             [1, 2, 1, 2, 2, 1, 2, 1]),
-                           (setup_factor(dr, tickers, size=1, data=[1]), 4, False,
-                            [1]*2),
-                           (setup_factor(dr, tickers, size=4, data=[1]*4), 4, False,
-                            [1]*8)
+                           (setup_factor(dr, tickers, size=1, data=[1]),
+                            4, False,
+                            [1] * 2),
+                           (setup_factor(dr, tickers, size=4, data=[1] * 4),
+                            4, False,
+                            [2] * 8)
                            ])
     def test_quantize_factor(self, factor, quantiles, by_group, expected_vals):
         quantized_factor = quantize_factor(factor,
@@ -154,6 +156,23 @@ class PerformanceTestCase(TestCase):
                           data=expected_vals,
                           name='quantile')
         assert_series_equal(quantized_factor, expected)
+
+    @parameterized.expand([(setup_factor(dr, tickers, size=4, data=[1,1,2,3]),
+                            4, False)
+                           ])
+    def test_quantize_factor_exception(self, factor, quantiles, by_group):
+        """
+        This documents an case when we meet confusing boundary
+
+        Some solution discussed at:
+        - http://stackoverflow.com/questions/20158597/how-to-qcut-with-non-unique-bin-edges
+        - https://github.com/pydata/pandas/issues/7751#issue-37814702
+
+        """
+        with self.assertRaises(ValueError):
+            quantized_factor = quantize_factor(factor,
+                                               quantiles=quantiles,
+                                               by_group=by_group)
 
     @parameterized.expand([([[1.0, 2.0, 3.0, 4.0],
                              [4.0, 3.0, 2.0, 1.0],


### PR DESCRIPTION
When we run create_factor_tear_sheet on either:

1. single value for factor per group (only one value over a date, or sector)
2. Field with discreet value (not sure if this is a correct use case for alphalens)

We are can run into exception seen below.

`qcut` over similar edges have been discussed but no solution is implemented yet "officially":

- http://stackoverflow.com/questions/20158597/how-to-qcut-with-non-unique-bin-edges
- https://github.com/pydata/pandas/issues/7751#issue-37814702

So this provided a simple work around for case when we run into this issue in a simple case, when we have only seen one value of the factor.


## Exception seen

```
/usr/local/lib/python2.7/dist-packages/alphalens/performance.pyc in quantile_calc(x, quantiles)
    242 
    243     def quantile_calc(x, quantiles):
--> 244         return pd.qcut(x, quantiles, labels=False) + 1
    245 
    246     grouper = ['date', 'sector'] if by_sector else ['date']

/usr/local/lib/python2.7/dist-packages/pandas/tools/tile.pyc in qcut(x, q, labels, retbins, precision)
    167     bins = algos.quantile(x, quantiles)
    168     return _bins_to_cuts(x, bins, labels=labels, retbins=retbins,precision=precision,
--> 169                          include_lowest=True)
    170 
    171 

/usr/local/lib/python2.7/dist-packages/pandas/tools/tile.pyc in _bins_to_cuts(x, bins, right, labels, retbins, precision, name, include_lowest)
    187 
    188     if len(algos.unique(bins)) < len(bins):
--> 189         raise ValueError('Bin edges must be unique: %s' % repr(bins))
    190 
    191     if include_lowest:

ValueError: Bin edges must be unique: array([-0.0030303, -0.0030303, -0.0030303, -0.0030303, -0.0030303,
       -0.0030303])
```
