### PR TITLE
Avoid grouping by day when calculating quantile mean returns

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -260,7 +260,7 @@ def quantize_factor(factor, quantiles=5, by_group=False):
 
 def mean_return_by_quantile(quantized_factor,
                             forward_returns,
-                            by_time=None,
+                            by_date=False,
                             by_group=False,
                             demeaned=True):
     """
@@ -277,8 +277,8 @@ def mean_return_by_quantile(quantized_factor,
         Period wise forward returns in indexed by date and asset and
         optional a custom group.
         Separate column for each forward return window.
-    by_time : str
-        The pandas str code for time grouping.
+    by_date : bool
+        If True, compute quantile bucket returns separately for each date.
     by_group : bool
         If True, compute quantile bucket returns separately for each group.
         Returns demeaning will occur on the group level.
@@ -309,8 +309,9 @@ def mean_return_by_quantile(quantized_factor,
                                 .set_index('quantile', append=True))
 
     grouper = []
-    if by_time is not None:
-        grouper.append(pd.TimeGrouper(by_time, level='date'))
+    if by_date:
+        grouper.append(
+            forward_returns_quantile.index.get_level_values('date'))        
 
     if by_group:
         grouper.append(

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -135,7 +135,7 @@ def create_factor_tear_sheet(factor,
 
     mean_ret_quant_daily, std_quant_daily = perf.mean_return_by_quantile(quantile_factor,
                                                                          forward_returns,
-                                                                         by_time='D',
+                                                                         by_date=True,
                                                                          by_group=False,
                                                                          demeaned=long_short)
 


### PR DESCRIPTION
Issue #88 

As alphalens is data frequency agnostic, the aggregation by day performed
when calculating quantile mean returns doesn't make sense all the time. It
could produce better plots for some scenarios, depending on data
frequency and data time span, but not for all the possible data given in
input to alphalens.

I am suggesting to remove the aggregation by day