### PR TITLE
Avoid period `1` persistence when new iterable is passed to create_factor_tear_sheet

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -398,7 +398,7 @@ def quantile_turnover(quantile_factor, quantile, period=1):
     new_names = (quant_name_sets - quant_name_sets.shift(period)).dropna()
     quant_turnover = new_names.apply(
         lambda x: len(x)) / quant_name_sets.apply(lambda x: len(x))
-
+    quant_turnover.name = quantile
     return quant_turnover
 
 

--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -585,7 +585,7 @@ def plot_top_bottom_quantile_turnover(quantile_turnover, period=1, ax=None):
 
     Parameters
     ----------
-    quantile_turnover: int:pd.Dataframe
+    quantile_turnover: pd.Dataframe
         Quantile turnover (each DataFrame column a quantile).
     period: int, optional
         Period over which to calculate the turnover        

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -95,7 +95,7 @@ def create_factor_tear_sheet(factor,
         plotted
     """
 
-    periods = sorted(list(periods))
+    periods = sorted(periods)
     turnover_periods = periods if turnover_for_all_periods else [1]
 
     can_group_adjust = groupby is not None

--- a/alphalens/tests/test_performance.py
+++ b/alphalens/tests/test_performance.py
@@ -180,6 +180,7 @@ class PerformanceTestCase(TestCase):
 
         expected = Series(
             index=quantized_test_factor.index.levels[0], data=expected_vals)
+        expected.name = test_quantile
 
         assert_series_equal(to, expected)
 


### PR DESCRIPTION
Issue #64 

Also, this patch calculates quantiles turnover only once (currently is done 2 times: one inside plot.summary_stats and one inside plot.plot_top_bottom_quantile_turnover)

When turnover_for_all_periods is False, only 1 period turnover/autocorrelation is computed and plotted (regardless of what periods are passed in create_factor_tear_sheet).

