### PR TITLE
Create sub tearsheets

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -171,12 +171,12 @@ def factor_returns(factor, forward_returns, long_short=True):
     weights = factor.groupby(level=['date']).apply(to_weights, long_short)
     weighted_returns = forward_returns.multiply(weights, axis=0)
 
-    long_short_adjusted_factor_returns = weighted_returns.groupby(level='date').sum()
+    factor_returns = weighted_returns.groupby(level='date').sum()
 
-    return long_short_adjusted_factor_returns
+    return factor_returns
 
 
-def factor_alpha_beta(factor, forward_returns, long_short_adjusted_factor_returns=None):
+def factor_alpha_beta(factor, forward_returns, factor_returns=None):
     """
     Computes the alpha (excess returns), alpha t-stat (alpha significance),
     and beta (market exposure) of a factor. A regression is run with
@@ -191,7 +191,7 @@ def factor_alpha_beta(factor, forward_returns, long_short_adjusted_factor_return
     forward_returns : pd.DataFrame - MultiIndex
         Period wise forward returns in indexed by date and asset.
         Separate column for each forward return window.
-    long_short_adjusted_factor_returns : pd.DataFrame
+    factor_returns : pd.DataFrame
         Period wise returns of dollar neutral portfolio weighted by factor value.
 
     Returns
@@ -200,23 +200,24 @@ def factor_alpha_beta(factor, forward_returns, long_short_adjusted_factor_return
         A list containing the alpha, beta, a t-stat(alpha)
         for the given factor and forward returns.
     """
-    if long_short_adjusted_factor_returns is None:
-        long_short_adjusted_factor_returns = factor_returns(factor, forward_returns)
+    if factor_returns is None:
+        factor_returns = factor_returns(factor, forward_returns)
 
     universe_ret = (forward_returns.groupby(level='date').mean()
-                          .loc[long_short_adjusted_factor_returns.index])
+                          .loc[factor_returns.index])
 
-    if isinstance(long_short_adjusted_factor_returns, pd.Series):
-        long_short_adjusted_factor_returns.name = universe_ret.columns.values[0]
-        long_short_adjusted_factor_returns = pd.DataFrame(long_short_adjusted_factor_returns)
+    if isinstance(factor_returns, pd.Series):
+        factor_returns.name = universe_ret.columns.values[0]
+        factor_returns = pd.DataFrame(factor_returns)
 
     alpha_beta = pd.DataFrame()
-    for period in long_short_adjusted_factor_returns.columns.values:
+    for period in factor_returns.columns.values:
         x = universe_ret[period].values
-        y = long_short_adjusted_factor_returns[period].values
+        y = factor_returns[period].values
 
         x = add_constant(x)
         reg_fit = OLS(y, x).fit()
+        t_alpha = reg_fit.tvalues[0]
         alpha, beta = reg_fit.params
 
         alpha_beta.loc['Ann. alpha', period] = (1 + alpha) ** (252.0/period) - 1
@@ -245,8 +246,8 @@ def quantize_factor(factor, quantiles=5, by_group=False):
         Factor quantiles indexed by date and asset.
     """
 
-    def quantile_calc(x, _quantiles):
-        return pd.qcut(x, _quantiles, labels=False) + 1
+    def quantile_calc(x, quantiles):
+        return pd.qcut(x, quantiles, labels=False) + 1
 
     grouper = ['date', 'group'] if by_group else ['date']
 
@@ -481,82 +482,3 @@ def average_cumulative_return_by_quantile(quantized_factor, prices,
 
     return quantized_factor.groupby(quantized_factor).apply(average_cumulative_return)
 
-
-def compute_returns_statistics(factor,
-                               forward_returns,
-                               quantiles,
-                               long_short,
-                               by_group=False):
-
-    long_short_adjusted_factor_returns = factor_returns(factor,
-                                                        forward_returns,
-                                                        long_short)
-
-    alpha_beta = factor_alpha_beta(factor,
-                                   forward_returns,
-                                   long_short_adjusted_factor_returns)
-
-    quantile_factor = quantize_factor(factor, quantiles, by_group)
-
-    mean_ret_quantile, std_quantile = mean_return_by_quantile(
-        quantile_factor,
-        forward_returns,
-        by_group=by_group,
-        demeaned=long_short)
-
-    mean_compret_quantile = mean_ret_quantile.apply(utils.compound_returns, axis=0)
-
-    mean_ret_quant_daily, std_quant_daily = mean_return_by_quantile(
-        quantile_factor,
-        forward_returns,
-        by_date=True,
-        by_group=by_group,
-        demeaned=long_short)
-
-    mean_compret_quant_daily = mean_ret_quant_daily.apply(utils.compound_returns,
-                                                          axis=0)
-
-    compstd_quant_daily = std_quant_daily.apply(utils.compound_returns, axis=0)
-
-    mean_ret_spread_quant, std_spread_quant = compute_mean_returns_spread(
-        mean_compret_quant_daily,
-        quantiles,
-        1,
-        std_err=compstd_quant_daily)
-
-    return alpha_beta, long_short_adjusted_factor_returns,\
-           mean_compret_quant_daily, mean_compret_quantile,\
-           mean_ret_quant_daily, mean_ret_quantile, mean_ret_spread_quant,\
-           quantile_factor, std_spread_quant
-
-
-def compute_turnover_statistics(factor, quantiles, turnover_periods, by_group=False):
-
-    quantile_factor = quantize_factor(factor,
-                                      quantiles,
-                                      by_group)
-
-    each_quantile_turnover = {p: pd.concat([quantile_turnover(
-        quantile_factor, q, p) for q in range(1, quantiles + 1)], axis=1)
-                         for p in turnover_periods}
-
-    factor_autocorrelation = pd.concat(
-        [factor_rank_autocorrelation(factor, period=p) for p in
-         turnover_periods], axis=1)
-    return factor_autocorrelation, each_quantile_turnover
-
-
-def compute_information_statistics(factor,
-                                   forward_returns,
-                                   group_adjust=False,
-                                   by_group=False):
-
-    ic = factor_information_coefficient(factor,
-                                        forward_returns,
-                                        group_adjust,
-                                        by_group)
-
-    mean_monthly_ic = mean_information_coefficient(factor,
-                                                   forward_returns,
-                                                   by_time="M")
-    return ic, mean_monthly_ic

--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -126,52 +126,6 @@ def summary_stats(ic_data,
         Period wise difference in quantile returns.
     """
 
-    plot_information_table(ic_data)
-    plot_turnover_table(autocorrelation_data, quantile_turnover)
-    plot_returns_table(alpha_beta,
-                       mean_ret_quantile,
-                       mean_ret_spread_quantile,
-                       quantized_factor)
-
-
-def plot_returns_table(alpha_beta, mean_ret_quantile, mean_ret_spread_quantile,
-                       quantized_factor):
-    max_quantile = quantized_factor.values.max()
-    min_quantile = quantized_factor.values.min()
-    returns_table = pd.DataFrame()
-    returns_table = returns_table.append(alpha_beta)
-    returns_table.loc[
-        "Mean Period Wise Return Top Quantile (bps)"] = mean_ret_quantile.loc[
-                                                            max_quantile] * DECIMAL_TO_BPS
-    returns_table.loc[
-        "Mean Period Wise Return Bottom Quantile (bps)"] = \
-    mean_ret_quantile.loc[
-        min_quantile] * DECIMAL_TO_BPS
-    returns_table.loc[
-        "Mean Period Wise Spread (bps)"] = mean_ret_spread_quantile.mean() \
-                                           * DECIMAL_TO_BPS
-
-    print("Returns Analysis")
-    utils.print_table(returns_table.apply(lambda x: x.round(3)))
-
-
-def plot_turnover_table(autocorrelation_data, quantile_turnover):
-    turnover_table = pd.DataFrame()
-    for period in sorted(quantile_turnover.keys()):
-        for quantile, p_data in quantile_turnover[period].iteritems():
-            turnover_table.loc["Quantile {} Mean Turnover ".format(quantile),
-                               "{}".format(period)] = p_data.mean()
-    auto_corr = pd.DataFrame()
-    for period, p_data in autocorrelation_data.iteritems():
-        auto_corr.loc["Mean Factor Rank Autocorrelation",
-                      "{}".format(period)] = p_data.mean()
-
-    print("Turnover Analysis")
-    utils.print_table(turnover_table.apply(lambda x: x.round(3)))
-    utils.print_table(auto_corr.apply(lambda x: x.round(3)))
-
-
-def plot_information_table(ic_data):
     ic_summary_table = pd.DataFrame()
     ic_summary_table["IC Mean"] = ic_data.mean()
     ic_summary_table["IC Std."] = ic_data.std()
@@ -181,11 +135,41 @@ def plot_information_table(ic_data):
     ic_summary_table["IC Skew"] = stats.skew(ic_data)
     ic_summary_table["IC Kurtosis"] = stats.kurtosis(ic_data)
     ic_summary_table["Ann. IR"] = (
-                                      ic_data.mean() / ic_data.std()) * np.sqrt(
-        252)
+        ic_data.mean() / ic_data.std()) * np.sqrt(252)
 
+    max_quantile = quantized_factor.values.max()
+    min_quantile = quantized_factor.values.min()
+
+    turnover_table = pd.DataFrame()
+    for period in sorted(quantile_turnover.keys()):
+        for quantile, p_data in quantile_turnover[period].iteritems():
+            turnover_table.loc["Quantile {} Mean Turnover ".format(quantile),
+                               "{}".format(period)] = p_data.mean()
+
+    auto_corr = pd.DataFrame()
+    for period, p_data in autocorrelation_data.iteritems():
+        auto_corr.loc["Mean Factor Rank Autocorrelation",
+                      "{}".format(period)] = p_data.mean()
+
+    returns_table = pd.DataFrame()
+    returns_table = returns_table.append(alpha_beta)
+    returns_table.loc[
+        "Mean Period Wise Return Top Quantile (bps)"] = mean_ret_quantile.loc[
+        max_quantile] * DECIMAL_TO_BPS
+    returns_table.loc[
+        "Mean Period Wise Return Bottom Quantile (bps)"] = mean_ret_quantile.loc[
+        min_quantile] * DECIMAL_TO_BPS
+    returns_table.loc[
+        "Mean Period Wise Spread (bps)"] = mean_ret_spread_quantile.mean() \
+        * DECIMAL_TO_BPS
+
+    print("Returns Analysis")
+    utils.print_table(returns_table.apply(lambda x: x.round(3)))
     print("Information Analysis")
     utils.print_table(ic_summary_table.apply(lambda x: x.round(3)).T)
+    print("Turnover Analysis")
+    utils.print_table(turnover_table.apply(lambda x: x.round(3)))
+    utils.print_table(auto_corr.apply(lambda x: x.round(3)))
 
 
 def plot_ic_ts(ic, ax=None):

--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -126,6 +126,52 @@ def summary_stats(ic_data,
         Period wise difference in quantile returns.
     """
 
+    plot_information_table(ic_data)
+    plot_turnover_table(autocorrelation_data, quantile_turnover)
+    plot_returns_table(alpha_beta,
+                       mean_ret_quantile,
+                       mean_ret_spread_quantile,
+                       quantized_factor)
+
+
+def plot_returns_table(alpha_beta, mean_ret_quantile, mean_ret_spread_quantile,
+                       quantized_factor):
+    max_quantile = quantized_factor.values.max()
+    min_quantile = quantized_factor.values.min()
+    returns_table = pd.DataFrame()
+    returns_table = returns_table.append(alpha_beta)
+    returns_table.loc[
+        "Mean Period Wise Return Top Quantile (bps)"] = mean_ret_quantile.loc[
+                                                            max_quantile] * DECIMAL_TO_BPS
+    returns_table.loc[
+        "Mean Period Wise Return Bottom Quantile (bps)"] = \
+    mean_ret_quantile.loc[
+        min_quantile] * DECIMAL_TO_BPS
+    returns_table.loc[
+        "Mean Period Wise Spread (bps)"] = mean_ret_spread_quantile.mean() \
+                                           * DECIMAL_TO_BPS
+
+    print("Returns Analysis")
+    utils.print_table(returns_table.apply(lambda x: x.round(3)))
+
+
+def plot_turnover_table(autocorrelation_data, quantile_turnover):
+    turnover_table = pd.DataFrame()
+    for period in sorted(quantile_turnover.keys()):
+        for quantile, p_data in quantile_turnover[period].iteritems():
+            turnover_table.loc["Quantile {} Mean Turnover ".format(quantile),
+                               "{}".format(period)] = p_data.mean()
+    auto_corr = pd.DataFrame()
+    for period, p_data in autocorrelation_data.iteritems():
+        auto_corr.loc["Mean Factor Rank Autocorrelation",
+                      "{}".format(period)] = p_data.mean()
+
+    print("Turnover Analysis")
+    utils.print_table(turnover_table.apply(lambda x: x.round(3)))
+    utils.print_table(auto_corr.apply(lambda x: x.round(3)))
+
+
+def plot_information_table(ic_data):
     ic_summary_table = pd.DataFrame()
     ic_summary_table["IC Mean"] = ic_data.mean()
     ic_summary_table["IC Std."] = ic_data.std()
@@ -135,41 +181,11 @@ def summary_stats(ic_data,
     ic_summary_table["IC Skew"] = stats.skew(ic_data)
     ic_summary_table["IC Kurtosis"] = stats.kurtosis(ic_data)
     ic_summary_table["Ann. IR"] = (
-        ic_data.mean() / ic_data.std()) * np.sqrt(252)
+                                      ic_data.mean() / ic_data.std()) * np.sqrt(
+        252)
 
-    max_quantile = quantized_factor.values.max()
-    min_quantile = quantized_factor.values.min()
-
-    turnover_table = pd.DataFrame()
-    for period in sorted(quantile_turnover.keys()):
-        for quantile, p_data in quantile_turnover[period].iteritems():
-            turnover_table.loc["Quantile {} Mean Turnover ".format(quantile),
-                               "{}".format(period)] = p_data.mean()
-
-    auto_corr = pd.DataFrame()
-    for period, p_data in autocorrelation_data.iteritems():
-        auto_corr.loc["Mean Factor Rank Autocorrelation",
-                      "{}".format(period)] = p_data.mean()
-
-    returns_table = pd.DataFrame()
-    returns_table = returns_table.append(alpha_beta)
-    returns_table.loc[
-        "Mean Period Wise Return Top Quantile (bps)"] = mean_ret_quantile.loc[
-        max_quantile] * DECIMAL_TO_BPS
-    returns_table.loc[
-        "Mean Period Wise Return Bottom Quantile (bps)"] = mean_ret_quantile.loc[
-        min_quantile] * DECIMAL_TO_BPS
-    returns_table.loc[
-        "Mean Period Wise Spread (bps)"] = mean_ret_spread_quantile.mean() \
-        * DECIMAL_TO_BPS
-
-    print("Returns Analysis")
-    utils.print_table(returns_table.apply(lambda x: x.round(3)))
     print("Information Analysis")
     utils.print_table(ic_summary_table.apply(lambda x: x.round(3)).T)
-    print("Turnover Analysis")
-    utils.print_table(turnover_table.apply(lambda x: x.round(3)))
-    utils.print_table(auto_corr.apply(lambda x: x.round(3)))
 
 
 def plot_ic_ts(ic, ax=None):

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -21,18 +21,221 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 
+# it makes life easier with grid plots
+class GridFigure(object):
+    def __init__(self, rows, cols):
+        self.rows = rows
+        self.cols = cols
+        self.fig = plt.figure(figsize=(14, rows * 7))
+        self.gs = gridspec.GridSpec(rows, cols, wspace=0.4, hspace=0.3)
+        self.curr_row = 0
+        self.curr_col = 0
+
+    def next_row(self):
+        if self.curr_col != 0:
+            self.curr_row += 1
+            self.curr_col = 0
+        subplt = plt.subplot(self.gs[self.curr_row, :])
+        self.curr_row += 1
+        return subplt
+
+    def next_cell(self):
+        if self.curr_col >= self.cols:
+            self.curr_row += 1
+            self.curr_col = 0
+        subplt = plt.subplot(self.gs[self.curr_row, self.curr_col])
+        self.curr_col += 1
+        return subplt
+
+
+def tear_sheet_setup(factor,
+                     prices,
+                     groupby=None,
+                     periods=(1, 5, 10),
+                     filter_zscore=10,
+                     groupby_labels=None,
+                     turnover_for_all_periods=False):
+
+        periods = sorted(periods)
+        turnover_periods = list(periods) if turnover_for_all_periods else [1]
+        can_group_adjust = groupby is not None
+
+        factor, forward_returns = utils.get_clean_factor_and_forward_returns(
+            factor,
+            prices,
+            groupby=groupby,
+            periods=periods,
+            filter_zscore=filter_zscore,
+            groupby_labels=groupby_labels)
+
+        return factor, forward_returns, periods, turnover_periods, can_group_adjust
+
+
 @plotting.plotting_context
-def create_factor_tear_sheet(factor,
+def create_summary_tearsheet(factor,
                              prices,
-                             groupby=None,
-                             show_groupby_plots=True,
                              periods=(1, 5, 10),
                              quantiles=5,
                              filter_zscore=10,
-                             groupby_labels=None,
                              long_short=True,
-                             avgretplot=(5, 15),
                              turnover_for_all_periods=False):
+
+    factor, forward_returns, periods,\
+    turnover_periods, can_group_adjust = tear_sheet_setup(factor=factor,
+                                                          prices=prices,
+                                                          periods=periods,
+                                                          filter_zscore=filter_zscore,
+                                                          turnover_for_all_periods=turnover_for_all_periods)
+
+
+    alpha_beta, factor_returns, mean_compret_quant_daily,\
+    mean_compret_quantile, mean_ret_quant_daily, mean_ret_quantile,\
+    mean_ret_spread_quant, quantile_factor, std_spread_quant = perf.compute_returns_statistics(
+        factor, forward_returns, quantiles, long_short)
+
+    ic, mean_monthly_ic = perf.compute_information_statistics(factor,
+                                                              forward_returns)
+
+    factor_autocorrelation, quantile_turnover = perf.compute_turnover_statistics(
+        factor, quantiles, turnover_periods)
+
+    fr_cols = len(periods)
+    vertical_sections = 2 + fr_cols * 3
+    gf = GridFigure(rows=vertical_sections, cols=1)
+
+
+    plotting.summary_stats(ic,
+                           alpha_beta,
+                           quantile_factor,
+                           mean_compret_quantile,
+                           quantile_turnover,
+                           factor_autocorrelation,
+                           mean_ret_spread_quant)
+
+    plotting.plot_quantile_returns_bar(mean_compret_quantile,
+                                       by_group=False,
+                                       ylim_percentiles=None,
+                                       ax=gf.next_row())
+
+    for p in turnover_periods:
+        plotting.plot_top_bottom_quantile_turnover(quantile_turnover[p], period=p, ax=gf.next_row())
+
+
+@plotting.plotting_context
+def create_returns_tear_sheet(factor,
+                              forward_returns,
+                              quantiles,
+                              long_short,
+                              by_group=False):
+
+    alpha_beta, factor_returns, mean_compret_quant_daily,\
+    mean_compret_quantile, mean_ret_quant_daily, mean_ret_quantile,\
+    mean_ret_spread_quant, quantile_factor, std_spread_quant = perf.compute_returns_statistics(
+        factor, forward_returns, quantiles, long_short, by_group)
+
+    fr_cols = len(forward_returns.columns)
+    vertical_sections = 2 + fr_cols * 3
+    gf = GridFigure(rows=vertical_sections, cols=1)
+
+    plotting.plot_returns_table(alpha_beta,
+                                mean_ret_quantile,
+                                mean_ret_spread_quant,
+                                quantile_factor)
+
+    plotting.plot_quantile_returns_bar(mean_compret_quantile,
+                                       by_group=False,
+                                       ylim_percentiles=None,
+                                       ax=gf.next_row())
+
+    plotting.plot_quantile_returns_violin(mean_compret_quant_daily,
+                                          ylim_percentiles=(1, 99),
+                                          ax=gf.next_row())
+
+    for p in forward_returns.columns:
+
+        plotting.plot_cumulative_returns(factor_returns[p],
+                                         period=p,
+                                         ax=gf.next_row())
+
+        plotting.plot_cumulative_returns_by_quantile(mean_ret_quant_daily[p],
+                                                     period=p,
+                                                     ax=gf.next_row())
+
+    ax_mean_quantile_returns_spread_ts = [ gf.next_row() for x in range(fr_cols) ]
+    plotting.plot_mean_quantile_returns_spread_time_series(mean_ret_spread_quant,
+                                                           std_err=std_spread_quant,
+                                                           bandwidth=0.5,
+                                                           ax=ax_mean_quantile_returns_spread_ts)
+
+
+@plotting.plotting_context
+def create_information_tear_sheet(factor,
+                                  forward_returns,
+                                  group_adjust=False,
+                                  by_group=False):
+
+    ic, mean_monthly_ic = perf.compute_information_statistics(factor,
+                                                              forward_returns,
+                                                              group_adjust,
+                                                              by_group)
+
+    columns_wide = 2
+    fr_cols = len(ic.columns)
+    rows_when_wide = (((fr_cols - 1) // columns_wide) + 1)
+    vertical_sections = fr_cols + 3 * rows_when_wide + 2 * fr_cols
+    gf = GridFigure(rows=vertical_sections, cols=columns_wide)
+
+    plotting.plot_information_table(ic)
+
+    ax_ic_ts = [gf.next_row() for _ in range(fr_cols)]
+    plotting.plot_ic_ts(ic, ax=ax_ic_ts)
+
+    ax_ic_hqq = [gf.next_cell() for _ in range(fr_cols * 2)]
+    plotting.plot_ic_hist(ic, ax=ax_ic_hqq[::2])
+    plotting.plot_ic_qq(ic, ax=ax_ic_hqq[1::2])
+
+    ax_monthly_ic_heatmap = [gf.next_cell() for x in range(fr_cols)]
+    plotting.plot_monthly_ic_heatmap(mean_monthly_ic, ax=ax_monthly_ic_heatmap)
+
+
+@plotting.plotting_context
+def create_turnover_tear_sheet(factor,
+                               quantiles,
+                               turnover_periods,
+                               by_group=False):
+
+    fr_cols = len(turnover_periods)
+    columns_wide = 1
+    rows_when_wide = (((fr_cols - 1) // 1) + 1)
+    vertical_sections = fr_cols + 3 * rows_when_wide + 2 * fr_cols
+    gf = GridFigure(rows=vertical_sections, cols=columns_wide)
+
+    factor_autocorrelation, quantile_turnover = perf.compute_turnover_statistics(
+        factor, quantiles, turnover_periods, by_group)
+
+    plotting.plot_turnover_table(factor_autocorrelation, quantile_turnover)
+
+    for p in turnover_periods:
+        plotting.plot_top_bottom_quantile_turnover(quantile_turnover[p],
+                                                   period=p,
+                                                   ax=gf.next_row())
+        plotting.plot_factor_rank_auto_correlation(factor_autocorrelation[p],
+                                                   period=p,
+                                                   ax=gf.next_row())
+
+
+@plotting.plotting_context
+def create_full_tear_sheet(factor,
+                           prices,
+                           groupby=None,
+                           show_groupby_plots=True,
+                           periods=(1, 5, 10),
+                           quantiles=5,
+                           filter_zscore=10,
+                           groupby_labels=None,
+                           long_short=True,
+                           avgretplot=(5, 15),
+                           turnover_for_all_periods=False):
     """
     Creates a full tear sheet for analysis and evaluating single
     return predicting (alpha) factor.
@@ -95,138 +298,28 @@ def create_factor_tear_sheet(factor,
         plotted
     """
 
-    periods = sorted(periods)
-    turnover_periods = list(periods) if turnover_for_all_periods else [1]
+    factor, forward_returns, periods, \
+    turnover_periods, can_group_adjust = tear_sheet_setup(factor=factor,
+                                                          prices=prices,
+                                                          groupby=groupby,
+                                                          periods=periods,
+                                                          filter_zscore=filter_zscore,
+                                                          groupby_labels=groupby_labels,
+                                                          turnover_for_all_periods=turnover_for_all_periods)
 
-    can_group_adjust = groupby is not None
-    factor, forward_returns = utils.get_clean_factor_and_forward_returns(factor,
-                                                                         prices,
-                                                                         groupby=groupby,
-                                                                         periods=periods,
-                                                                         filter_zscore=filter_zscore,
-                                                                         groupby_labels=groupby_labels)
+    create_returns_tear_sheet(factor, forward_returns, quantiles, long_short)
+    create_information_tear_sheet(factor, forward_returns)
+    create_turnover_tear_sheet(factor, quantiles, turnover_periods)
 
-    ic = perf.factor_information_coefficient(factor,
-                                             forward_returns,
-                                             group_adjust=False,
-                                             by_group=False)
-
-    mean_monthly_ic = perf.mean_information_coefficient(factor,
-                                                        forward_returns,
-                                                        by_time="M")
-
-    factor_returns = perf.factor_returns(factor, forward_returns, long_short)
-
-    alpha_beta = perf.factor_alpha_beta(factor,
-                                        forward_returns,
-                                        factor_returns=factor_returns)
-
-    quantile_factor = perf.quantize_factor(factor,
-                                           by_group=False,
-                                           quantiles=quantiles)
-
-    def compound_returns(period_ret):
-        period = int(period_ret.name)
-        return period_ret.add(1).pow(1./period).sub(1)
-
-    mean_ret_quantile, std_quantile = perf.mean_return_by_quantile(quantile_factor,
-                                                                   forward_returns,
-                                                                   by_group=False,
-                                                                   demeaned=long_short)
-                                                                   
-    mean_compret_quantile = mean_ret_quantile.apply(compound_returns, axis=0)
-
-    mean_ret_quant_daily, std_quant_daily = perf.mean_return_by_quantile(quantile_factor,
-                                                                         forward_returns,
-                                                                         by_date=True,
-                                                                         by_group=False,
-                                                                         demeaned=long_short)
-
-    mean_compret_quant_daily = mean_ret_quant_daily.apply(compound_returns, axis=0)
-    compstd_quant_daily = std_quant_daily.apply(compound_returns, axis=0)
-
-    mean_ret_spread_quant, std_spread_quant = perf.compute_mean_returns_spread(mean_compret_quant_daily,
-                                                                               quantiles,
-                                                                               1,
-                                                                               std_err=compstd_quant_daily)
-
-    quantile_turnover = {p: pd.concat([perf.quantile_turnover(
-        quantile_factor, q, p) for q in range(1, quantiles + 1)], axis=1) for p in turnover_periods}
-
-    factor_autocorrelation = pd.concat(
-        [perf.factor_rank_autocorrelation(factor, period=p) for p in turnover_periods], axis=1)
-
-    ## PLOTTING ##
-    plotting.summary_stats(ic,
-                           alpha_beta,
-                           quantile_factor,
-                           mean_compret_quantile,
-                           quantile_turnover,
-                           factor_autocorrelation,
-                           mean_ret_spread_quant)
-
-    # it makes life easier with grid plots
-    class GridFigure(object):
-    
-        def __init__(self, rows, cols):
-            self.rows = rows
-            self.cols = cols
-            self.fig  = plt.figure(figsize=(14, rows * 7))
-            self.gs   = gridspec.GridSpec(rows, cols, wspace=0.4, hspace=0.3)
-            self.curr_row = 0
-            self.curr_col = 0
-            
-        def next_row(self):
-            if self.curr_col != 0:
-                self.curr_row += 1
-                self.curr_col = 0
-            subplt = plt.subplot(self.gs[self.curr_row, :])
-            self.curr_row += 1
-            return subplt 
-            
-        def next_cell(self):
-            if self.curr_col >= self.cols:
-                self.curr_row += 1
-                self.curr_col = 0
-            subplt = plt.subplot(self.gs[self.curr_row, self.curr_col])
-            self.curr_col += 1
-            return subplt
-            
-    # Returns
-    fr_cols = len(periods)
-    vertical_sections = 2 + fr_cols * 3
-    gf = GridFigure(rows=vertical_sections, cols=1)
-
-    plotting.plot_quantile_returns_bar(mean_compret_quantile,
-                                       by_group=False,
-                                       ylim_percentiles=None,
-                                       ax=gf.next_row())
-
-    plotting.plot_quantile_returns_violin(mean_compret_quant_daily,
-                                          ylim_percentiles=(1, 99),
-                                          ax=gf.next_row())
-    
-    for p in periods:
-    
-        plotting.plot_cumulative_returns(factor_returns[p], period=p,
-                                         ax=gf.next_row())
-                                         
-        plotting.plot_cumulative_returns_by_quantile(mean_ret_quant_daily[p], period=p,
-                                                     ax=gf.next_row())
-
-    ax_mean_quantile_returns_spread_ts = [ gf.next_row() for x in range(fr_cols) ]
-    plotting.plot_mean_quantile_returns_spread_time_series(mean_ret_spread_quant,
-                                                           std_err=std_spread_quant,
-                                                           bandwidth=0.5,
-                                                           ax=ax_mean_quantile_returns_spread_ts)
+    quantile_factor = perf.quantize_factor(factor, quantiles, False)
 
     # Average Cumulative Returns
     if avgretplot is not None:
-    
+
         before, after = avgretplot
         after = max(after, max(periods) + 1)
         avgretplot = before, after
-        
+
         avg_cumulative_returns = perf.average_cumulative_return_by_quantile(quantile_factor,
                                                                             prices,
                                                                             periods_before=before,
@@ -238,32 +331,9 @@ def create_factor_tear_sheet(factor,
         plotting.plot_quantile_average_cumulative_return(avg_cumulative_returns, by_quantile=False,
                                                          std_bar=False, ax=gf.next_row())
 
-        ax_avg_cumulative_returns_by_q = [ gf.next_cell() for x in range(quantiles) ]
+        ax_avg_cumulative_returns_by_q = [ gf.next_cell() for _ in range(quantiles) ]
         plotting.plot_quantile_average_cumulative_return(avg_cumulative_returns, by_quantile=True,
                                                          std_bar=True, ax=ax_avg_cumulative_returns_by_q)
-
-    # IC
-    columns_wide = 2
-    rows_when_wide = (((fr_cols - 1) // columns_wide) + 1)
-    vertical_sections = fr_cols + 3 * rows_when_wide + 2 * len(periods)
-    gf = GridFigure(rows=vertical_sections, cols=columns_wide)
-
-    ax_ic_ts = [ gf.next_row() for x in range(fr_cols) ]
-    plotting.plot_ic_ts(ic, ax=ax_ic_ts)
-
-    ax_ic_hqq = [ gf.next_cell() for x in range(fr_cols * 2) ]
-    plotting.plot_ic_hist(ic, ax=ax_ic_hqq[::2])
-    plotting.plot_ic_qq(ic, ax=ax_ic_hqq[1::2])
-
-    ax_monthly_ic_heatmap = [ gf.next_cell() for x in range(fr_cols) ]
-    plotting.plot_monthly_ic_heatmap(mean_monthly_ic, ax=ax_monthly_ic_heatmap)
-
-    for p in turnover_periods:
-
-        plotting.plot_top_bottom_quantile_turnover(quantile_turnover[p], period=p, ax=gf.next_row())
-
-        plotting.plot_factor_rank_auto_correlation(
-            factor_autocorrelation[p], period=p, ax=gf.next_row())
 
     # Group Specific Breakdown
     if can_group_adjust and show_groupby_plots:
@@ -275,30 +345,30 @@ def create_factor_tear_sheet(factor,
                                                                                                       forward_returns,
                                                                                                       by_group=True,
                                                                                                       demeaned=True)
-        mean_compret_quantile_group = mean_return_quantile_group.apply(compound_returns, axis=0)
-        
+        mean_compret_quantile_group = mean_return_quantile_group.apply(utils.compound_returns, axis=0)
+
         num_groups = len(ic_by_group.index.get_level_values('group').unique())
         vertical_sections = 1 + (((num_groups - 1) // 2) + 1)
         gf = GridFigure(rows=vertical_sections, cols=2)
-        
+
         plotting.plot_ic_by_group(ic_by_group, ax=gf.next_row())
 
-        ax_quantile_returns_bar_by_group = [ gf.next_cell() for x in range(num_groups) ]
+        ax_quantile_returns_bar_by_group = [ gf.next_cell() for _ in range(num_groups) ]
         plotting.plot_quantile_returns_bar(mean_compret_quantile_group,
                                            by_group=True,
                                            ylim_percentiles=(5, 95),
                                            ax=ax_quantile_returns_bar_by_group)
-                                           
-                                               
+
+
         if avgretplot is not None:
-            
+
             before, after = avgretplot
             num_group = len(quantile_factor.index.get_level_values('group').unique())
             vertical_sections = ((num_groups - 1) // 2) + 1
             gf = GridFigure(rows=vertical_sections, cols=2)
-            
+
             for group, g_factor in quantile_factor.groupby(level='group'):
-            
+
                 avg_cumulative_returns = perf.average_cumulative_return_by_quantile(g_factor,
                                                                                     prices,
                                                                                     periods_before=before,
@@ -307,5 +377,6 @@ def create_factor_tear_sheet(factor,
 
                 plotting.plot_quantile_average_cumulative_return(avg_cumulative_returns, by_quantile=False,
                                                                  std_bar=False, title=group, ax=gf.next_cell())
+
 
 

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -21,221 +21,18 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 
-# it makes life easier with grid plots
-class GridFigure(object):
-    def __init__(self, rows, cols):
-        self.rows = rows
-        self.cols = cols
-        self.fig = plt.figure(figsize=(14, rows * 7))
-        self.gs = gridspec.GridSpec(rows, cols, wspace=0.4, hspace=0.3)
-        self.curr_row = 0
-        self.curr_col = 0
-
-    def next_row(self):
-        if self.curr_col != 0:
-            self.curr_row += 1
-            self.curr_col = 0
-        subplt = plt.subplot(self.gs[self.curr_row, :])
-        self.curr_row += 1
-        return subplt
-
-    def next_cell(self):
-        if self.curr_col >= self.cols:
-            self.curr_row += 1
-            self.curr_col = 0
-        subplt = plt.subplot(self.gs[self.curr_row, self.curr_col])
-        self.curr_col += 1
-        return subplt
-
-
-def tear_sheet_setup(factor,
-                     prices,
-                     groupby=None,
-                     periods=(1, 5, 10),
-                     filter_zscore=10,
-                     groupby_labels=None,
-                     turnover_for_all_periods=False):
-
-        periods = sorted(periods)
-        turnover_periods = list(periods) if turnover_for_all_periods else [1]
-        can_group_adjust = groupby is not None
-
-        factor, forward_returns = utils.get_clean_factor_and_forward_returns(
-            factor,
-            prices,
-            groupby=groupby,
-            periods=periods,
-            filter_zscore=filter_zscore,
-            groupby_labels=groupby_labels)
-
-        return factor, forward_returns, periods, turnover_periods, can_group_adjust
-
-
 @plotting.plotting_context
-def create_summary_tearsheet(factor,
+def create_factor_tear_sheet(factor,
                              prices,
+                             groupby=None,
+                             show_groupby_plots=True,
                              periods=(1, 5, 10),
                              quantiles=5,
                              filter_zscore=10,
+                             groupby_labels=None,
                              long_short=True,
+                             avgretplot=(5, 15),
                              turnover_for_all_periods=False):
-
-    factor, forward_returns, periods,\
-    turnover_periods, can_group_adjust = tear_sheet_setup(factor=factor,
-                                                          prices=prices,
-                                                          periods=periods,
-                                                          filter_zscore=filter_zscore,
-                                                          turnover_for_all_periods=turnover_for_all_periods)
-
-
-    alpha_beta, factor_returns, mean_compret_quant_daily,\
-    mean_compret_quantile, mean_ret_quant_daily, mean_ret_quantile,\
-    mean_ret_spread_quant, quantile_factor, std_spread_quant = perf.compute_returns_statistics(
-        factor, forward_returns, quantiles, long_short)
-
-    ic, mean_monthly_ic = perf.compute_information_statistics(factor,
-                                                              forward_returns)
-
-    factor_autocorrelation, quantile_turnover = perf.compute_turnover_statistics(
-        factor, quantiles, turnover_periods)
-
-    fr_cols = len(periods)
-    vertical_sections = 2 + fr_cols * 3
-    gf = GridFigure(rows=vertical_sections, cols=1)
-
-
-    plotting.summary_stats(ic,
-                           alpha_beta,
-                           quantile_factor,
-                           mean_compret_quantile,
-                           quantile_turnover,
-                           factor_autocorrelation,
-                           mean_ret_spread_quant)
-
-    plotting.plot_quantile_returns_bar(mean_compret_quantile,
-                                       by_group=False,
-                                       ylim_percentiles=None,
-                                       ax=gf.next_row())
-
-    for p in turnover_periods:
-        plotting.plot_top_bottom_quantile_turnover(quantile_turnover[p], period=p, ax=gf.next_row())
-
-
-@plotting.plotting_context
-def create_returns_tear_sheet(factor,
-                              forward_returns,
-                              quantiles,
-                              long_short,
-                              by_group=False):
-
-    alpha_beta, factor_returns, mean_compret_quant_daily,\
-    mean_compret_quantile, mean_ret_quant_daily, mean_ret_quantile,\
-    mean_ret_spread_quant, quantile_factor, std_spread_quant = perf.compute_returns_statistics(
-        factor, forward_returns, quantiles, long_short, by_group)
-
-    fr_cols = len(forward_returns.columns)
-    vertical_sections = 2 + fr_cols * 3
-    gf = GridFigure(rows=vertical_sections, cols=1)
-
-    plotting.plot_returns_table(alpha_beta,
-                                mean_ret_quantile,
-                                mean_ret_spread_quant,
-                                quantile_factor)
-
-    plotting.plot_quantile_returns_bar(mean_compret_quantile,
-                                       by_group=False,
-                                       ylim_percentiles=None,
-                                       ax=gf.next_row())
-
-    plotting.plot_quantile_returns_violin(mean_compret_quant_daily,
-                                          ylim_percentiles=(1, 99),
-                                          ax=gf.next_row())
-
-    for p in forward_returns.columns:
-
-        plotting.plot_cumulative_returns(factor_returns[p],
-                                         period=p,
-                                         ax=gf.next_row())
-
-        plotting.plot_cumulative_returns_by_quantile(mean_ret_quant_daily[p],
-                                                     period=p,
-                                                     ax=gf.next_row())
-
-    ax_mean_quantile_returns_spread_ts = [ gf.next_row() for x in range(fr_cols) ]
-    plotting.plot_mean_quantile_returns_spread_time_series(mean_ret_spread_quant,
-                                                           std_err=std_spread_quant,
-                                                           bandwidth=0.5,
-                                                           ax=ax_mean_quantile_returns_spread_ts)
-
-
-@plotting.plotting_context
-def create_information_tear_sheet(factor,
-                                  forward_returns,
-                                  group_adjust=False,
-                                  by_group=False):
-
-    ic, mean_monthly_ic = perf.compute_information_statistics(factor,
-                                                              forward_returns,
-                                                              group_adjust,
-                                                              by_group)
-
-    columns_wide = 2
-    fr_cols = len(ic.columns)
-    rows_when_wide = (((fr_cols - 1) // columns_wide) + 1)
-    vertical_sections = fr_cols + 3 * rows_when_wide + 2 * fr_cols
-    gf = GridFigure(rows=vertical_sections, cols=columns_wide)
-
-    plotting.plot_information_table(ic)
-
-    ax_ic_ts = [gf.next_row() for _ in range(fr_cols)]
-    plotting.plot_ic_ts(ic, ax=ax_ic_ts)
-
-    ax_ic_hqq = [gf.next_cell() for _ in range(fr_cols * 2)]
-    plotting.plot_ic_hist(ic, ax=ax_ic_hqq[::2])
-    plotting.plot_ic_qq(ic, ax=ax_ic_hqq[1::2])
-
-    ax_monthly_ic_heatmap = [gf.next_cell() for x in range(fr_cols)]
-    plotting.plot_monthly_ic_heatmap(mean_monthly_ic, ax=ax_monthly_ic_heatmap)
-
-
-@plotting.plotting_context
-def create_turnover_tear_sheet(factor,
-                               quantiles,
-                               turnover_periods,
-                               by_group=False):
-
-    fr_cols = len(turnover_periods)
-    columns_wide = 1
-    rows_when_wide = (((fr_cols - 1) // 1) + 1)
-    vertical_sections = fr_cols + 3 * rows_when_wide + 2 * fr_cols
-    gf = GridFigure(rows=vertical_sections, cols=columns_wide)
-
-    factor_autocorrelation, quantile_turnover = perf.compute_turnover_statistics(
-        factor, quantiles, turnover_periods, by_group)
-
-    plotting.plot_turnover_table(factor_autocorrelation, quantile_turnover)
-
-    for p in turnover_periods:
-        plotting.plot_top_bottom_quantile_turnover(quantile_turnover[p],
-                                                   period=p,
-                                                   ax=gf.next_row())
-        plotting.plot_factor_rank_auto_correlation(factor_autocorrelation[p],
-                                                   period=p,
-                                                   ax=gf.next_row())
-
-
-@plotting.plotting_context
-def create_full_tear_sheet(factor,
-                           prices,
-                           groupby=None,
-                           show_groupby_plots=True,
-                           periods=(1, 5, 10),
-                           quantiles=5,
-                           filter_zscore=10,
-                           groupby_labels=None,
-                           long_short=True,
-                           avgretplot=(5, 15),
-                           turnover_for_all_periods=False):
     """
     Creates a full tear sheet for analysis and evaluating single
     return predicting (alpha) factor.
@@ -298,28 +95,138 @@ def create_full_tear_sheet(factor,
         plotted
     """
 
-    factor, forward_returns, periods, \
-    turnover_periods, can_group_adjust = tear_sheet_setup(factor=factor,
-                                                          prices=prices,
-                                                          groupby=groupby,
-                                                          periods=periods,
-                                                          filter_zscore=filter_zscore,
-                                                          groupby_labels=groupby_labels,
-                                                          turnover_for_all_periods=turnover_for_all_periods)
+    periods = sorted(periods)
+    turnover_periods = list(periods) if turnover_for_all_periods else [1]
 
-    create_returns_tear_sheet(factor, forward_returns, quantiles, long_short)
-    create_information_tear_sheet(factor, forward_returns)
-    create_turnover_tear_sheet(factor, quantiles, turnover_periods)
+    can_group_adjust = groupby is not None
+    factor, forward_returns = utils.get_clean_factor_and_forward_returns(factor,
+                                                                         prices,
+                                                                         groupby=groupby,
+                                                                         periods=periods,
+                                                                         filter_zscore=filter_zscore,
+                                                                         groupby_labels=groupby_labels)
 
-    quantile_factor = perf.quantize_factor(factor, quantiles, False)
+    ic = perf.factor_information_coefficient(factor,
+                                             forward_returns,
+                                             group_adjust=False,
+                                             by_group=False)
+
+    mean_monthly_ic = perf.mean_information_coefficient(factor,
+                                                        forward_returns,
+                                                        by_time="M")
+
+    factor_returns = perf.factor_returns(factor, forward_returns, long_short)
+
+    alpha_beta = perf.factor_alpha_beta(factor,
+                                        forward_returns,
+                                        factor_returns=factor_returns)
+
+    quantile_factor = perf.quantize_factor(factor,
+                                           by_group=False,
+                                           quantiles=quantiles)
+
+    def compound_returns(period_ret):
+        period = int(period_ret.name)
+        return period_ret.add(1).pow(1./period).sub(1)
+
+    mean_ret_quantile, std_quantile = perf.mean_return_by_quantile(quantile_factor,
+                                                                   forward_returns,
+                                                                   by_group=False,
+                                                                   demeaned=long_short)
+                                                                   
+    mean_compret_quantile = mean_ret_quantile.apply(compound_returns, axis=0)
+
+    mean_ret_quant_daily, std_quant_daily = perf.mean_return_by_quantile(quantile_factor,
+                                                                         forward_returns,
+                                                                         by_date=True,
+                                                                         by_group=False,
+                                                                         demeaned=long_short)
+
+    mean_compret_quant_daily = mean_ret_quant_daily.apply(compound_returns, axis=0)
+    compstd_quant_daily = std_quant_daily.apply(compound_returns, axis=0)
+
+    mean_ret_spread_quant, std_spread_quant = perf.compute_mean_returns_spread(mean_compret_quant_daily,
+                                                                               quantiles,
+                                                                               1,
+                                                                               std_err=compstd_quant_daily)
+
+    quantile_turnover = {p: pd.concat([perf.quantile_turnover(
+        quantile_factor, q, p) for q in range(1, quantiles + 1)], axis=1) for p in turnover_periods}
+
+    factor_autocorrelation = pd.concat(
+        [perf.factor_rank_autocorrelation(factor, period=p) for p in turnover_periods], axis=1)
+
+    ## PLOTTING ##
+    plotting.summary_stats(ic,
+                           alpha_beta,
+                           quantile_factor,
+                           mean_compret_quantile,
+                           quantile_turnover,
+                           factor_autocorrelation,
+                           mean_ret_spread_quant)
+
+    # it makes life easier with grid plots
+    class GridFigure(object):
+    
+        def __init__(self, rows, cols):
+            self.rows = rows
+            self.cols = cols
+            self.fig  = plt.figure(figsize=(14, rows * 7))
+            self.gs   = gridspec.GridSpec(rows, cols, wspace=0.4, hspace=0.3)
+            self.curr_row = 0
+            self.curr_col = 0
+            
+        def next_row(self):
+            if self.curr_col != 0:
+                self.curr_row += 1
+                self.curr_col = 0
+            subplt = plt.subplot(self.gs[self.curr_row, :])
+            self.curr_row += 1
+            return subplt 
+            
+        def next_cell(self):
+            if self.curr_col >= self.cols:
+                self.curr_row += 1
+                self.curr_col = 0
+            subplt = plt.subplot(self.gs[self.curr_row, self.curr_col])
+            self.curr_col += 1
+            return subplt
+            
+    # Returns
+    fr_cols = len(periods)
+    vertical_sections = 2 + fr_cols * 3
+    gf = GridFigure(rows=vertical_sections, cols=1)
+
+    plotting.plot_quantile_returns_bar(mean_compret_quantile,
+                                       by_group=False,
+                                       ylim_percentiles=None,
+                                       ax=gf.next_row())
+
+    plotting.plot_quantile_returns_violin(mean_compret_quant_daily,
+                                          ylim_percentiles=(1, 99),
+                                          ax=gf.next_row())
+    
+    for p in periods:
+    
+        plotting.plot_cumulative_returns(factor_returns[p], period=p,
+                                         ax=gf.next_row())
+                                         
+        plotting.plot_cumulative_returns_by_quantile(mean_ret_quant_daily[p], period=p,
+                                                     ax=gf.next_row())
+
+    ax_mean_quantile_returns_spread_ts = [ gf.next_row() for x in range(fr_cols) ]
+    plotting.plot_mean_quantile_returns_spread_time_series(mean_ret_spread_quant,
+                                                           std_err=std_spread_quant,
+                                                           bandwidth=0.5,
+                                                           ax=ax_mean_quantile_returns_spread_ts)
 
     # Average Cumulative Returns
     if avgretplot is not None:
-
+    
         before, after = avgretplot
         after = max(after, max(periods) + 1)
         avgretplot = before, after
-
+        
         avg_cumulative_returns = perf.average_cumulative_return_by_quantile(quantile_factor,
                                                                             prices,
                                                                             periods_before=before,
@@ -331,9 +238,32 @@ def create_full_tear_sheet(factor,
         plotting.plot_quantile_average_cumulative_return(avg_cumulative_returns, by_quantile=False,
                                                          std_bar=False, ax=gf.next_row())
 
-        ax_avg_cumulative_returns_by_q = [ gf.next_cell() for _ in range(quantiles) ]
+        ax_avg_cumulative_returns_by_q = [ gf.next_cell() for x in range(quantiles) ]
         plotting.plot_quantile_average_cumulative_return(avg_cumulative_returns, by_quantile=True,
                                                          std_bar=True, ax=ax_avg_cumulative_returns_by_q)
+
+    # IC
+    columns_wide = 2
+    rows_when_wide = (((fr_cols - 1) // columns_wide) + 1)
+    vertical_sections = fr_cols + 3 * rows_when_wide + 2 * len(periods)
+    gf = GridFigure(rows=vertical_sections, cols=columns_wide)
+
+    ax_ic_ts = [ gf.next_row() for x in range(fr_cols) ]
+    plotting.plot_ic_ts(ic, ax=ax_ic_ts)
+
+    ax_ic_hqq = [ gf.next_cell() for x in range(fr_cols * 2) ]
+    plotting.plot_ic_hist(ic, ax=ax_ic_hqq[::2])
+    plotting.plot_ic_qq(ic, ax=ax_ic_hqq[1::2])
+
+    ax_monthly_ic_heatmap = [ gf.next_cell() for x in range(fr_cols) ]
+    plotting.plot_monthly_ic_heatmap(mean_monthly_ic, ax=ax_monthly_ic_heatmap)
+
+    for p in turnover_periods:
+
+        plotting.plot_top_bottom_quantile_turnover(quantile_turnover[p], period=p, ax=gf.next_row())
+
+        plotting.plot_factor_rank_auto_correlation(
+            factor_autocorrelation[p], period=p, ax=gf.next_row())
 
     # Group Specific Breakdown
     if can_group_adjust and show_groupby_plots:
@@ -345,30 +275,30 @@ def create_full_tear_sheet(factor,
                                                                                                       forward_returns,
                                                                                                       by_group=True,
                                                                                                       demeaned=True)
-        mean_compret_quantile_group = mean_return_quantile_group.apply(utils.compound_returns, axis=0)
-
+        mean_compret_quantile_group = mean_return_quantile_group.apply(compound_returns, axis=0)
+        
         num_groups = len(ic_by_group.index.get_level_values('group').unique())
         vertical_sections = 1 + (((num_groups - 1) // 2) + 1)
         gf = GridFigure(rows=vertical_sections, cols=2)
-
+        
         plotting.plot_ic_by_group(ic_by_group, ax=gf.next_row())
 
-        ax_quantile_returns_bar_by_group = [ gf.next_cell() for _ in range(num_groups) ]
+        ax_quantile_returns_bar_by_group = [ gf.next_cell() for x in range(num_groups) ]
         plotting.plot_quantile_returns_bar(mean_compret_quantile_group,
                                            by_group=True,
                                            ylim_percentiles=(5, 95),
                                            ax=ax_quantile_returns_bar_by_group)
-
-
+                                           
+                                               
         if avgretplot is not None:
-
+            
             before, after = avgretplot
             num_group = len(quantile_factor.index.get_level_values('group').unique())
             vertical_sections = ((num_groups - 1) // 2) + 1
             gf = GridFigure(rows=vertical_sections, cols=2)
-
+            
             for group, g_factor in quantile_factor.groupby(level='group'):
-
+            
                 avg_cumulative_returns = perf.average_cumulative_return_by_quantile(g_factor,
                                                                                     prices,
                                                                                     periods_before=before,
@@ -377,6 +307,5 @@ def create_full_tear_sheet(factor,
 
                 plotting.plot_quantile_average_cumulative_return(avg_cumulative_returns, by_quantile=False,
                                                                  std_bar=False, title=group, ax=gf.next_cell())
-
 
 

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -298,8 +298,3 @@ def common_start_returns(factor, prices, before, after, mean_by_date, demeaned):
 
     return pd.concat(all_returns, axis=1)
 
-
-def compound_returns(period_ret):
-    period = int(period_ret.name)
-    return period_ret.add(1).pow(1. / period).sub(1)
-

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -298,3 +298,8 @@ def common_start_returns(factor, prices, before, after, mean_by_date, demeaned):
 
     return pd.concat(all_returns, axis=1)
 
+
+def compound_returns(period_ret):
+    period = int(period_ret.name)
+    return period_ret.add(1).pow(1. / period).sub(1)
+


### PR DESCRIPTION
This breaks down the full tear sheet into multiple smaller ones covering: returns, information, and turnover analysis.

This PR is aimed mainly at issue #106 so Thomas your thoughts would be great!

This is a first start so things are pretty rough, and it definitely won't pass tests but I think there will be a lot of discussion so I'm not too worried.
