### PR TITLE
Fix issue #116 plot_mean_quantile_returns_spread_time_series seems failed with dataframe input

### DIFF
--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -487,11 +487,12 @@ def plot_mean_quantile_returns_spread_time_series(mean_returns_spread,
             ax = [None for a in mean_returns_spread.columns]
 
         ymin, ymax = (None, None)
-        for a, (name, fr_column) in zip(ax, mean_returns_spread.iteritems()):
+        for (i, a), (name, fr_column) in zip(enumerate(ax), mean_returns_spread.iteritems()):
             stdn = None if std_err is None else std_err[name]
-            plot_mean_quantile_returns_spread_time_series(fr_column,
-                                                          std_err=stdn,
-                                                          ax=a)
+            a = plot_mean_quantile_returns_spread_time_series(fr_column,
+                                                                   std_err=stdn,
+                                                                   ax=a)
+            ax[i] = a
             curr_ymin, curr_ymax = a.get_ylim()
             ymin = curr_ymin if ymin is None else min(ymin, curr_ymin)
             ymax = curr_ymax if ymax is None else max(ymax, curr_ymax)                                                          

--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -490,8 +490,8 @@ def plot_mean_quantile_returns_spread_time_series(mean_returns_spread,
         for (i, a), (name, fr_column) in zip(enumerate(ax), mean_returns_spread.iteritems()):
             stdn = None if std_err is None else std_err[name]
             a = plot_mean_quantile_returns_spread_time_series(fr_column,
-                                                                   std_err=stdn,
-                                                                   ax=a)
+                                                              std_err=stdn,
+                                                              ax=a)
             ax[i] = a
             curr_ymin, curr_ymax = a.get_ylim()
             ymin = curr_ymin if ymin is None else min(ymin, curr_ymin)


### PR DESCRIPTION
let `a` to be the output of the recursive call, and the replace the corresponding element in list `ax` with it, so that `a.get_ylim()` have the right method :
```python
        for (i, a), (name, fr_column) in zip(enumerate(ax), mean_returns_spread.iteritems()):
            stdn = None if std_err is None else std_err[name]
            a = plot_mean_quantile_returns_spread_time_series(fr_column,
                                                                   std_err=stdn,
                                                                   ax=a)
            ax[i] = a
            curr_ymin, curr_ymax = a.get_ylim()
```