### PR TITLE
BUG: demeaning in average_cumulative_return_by_quantile

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -473,7 +473,8 @@ def average_cumulative_return_by_quantile(quantized_factor, prices,
     Parameters
     ----------
     quantized_factor : pd.Series
-        Factor quantiles indexed by date and asset.
+        Factor quantiles indexed by date and asset and
+        optional a custom group.
     prices : pd.DataFrame
         A wide form Pandas DataFrame indexed by date with assets
         in the columns. Pricing data should span the factor
@@ -492,13 +493,11 @@ def average_cumulative_return_by_quantile(quantized_factor, prices,
     -periods_before to periods_after
     """
 
-    assets = list(set(quantized_factor.index.get_level_values('asset')))
-    prices = prices[assets]
-
     def average_cumulative_return(q_fact):
+        demean = quantized_factor if demeaned else None
         q_returns = utils.common_start_returns(q_fact, prices,
                                                periods_before, periods_after,
-                                               True, True, demeaned)
+                                               True, True, demean)
         return pd.DataFrame( {'mean': q_returns.mean(axis=1), 'std': q_returns.std(axis=1)} ).T
 
     return quantized_factor.groupby(quantized_factor).apply(average_cumulative_return)

--- a/alphalens/tests/test_performance.py
+++ b/alphalens/tests/test_performance.py
@@ -406,25 +406,8 @@ class PerformanceTestCase(TestCase):
         dr.name = 'date'
         tickers = ['A', 'B', 'C', 'D']
         r1, r2, r3, r4 = (1.25, 1.50, 1.00, 0.50)
-        prices = DataFrame(index=dr, columns=tickers,
-                           data=[[r1**1,  r2**1,  r3**1,  r4**1 ],
-                                 [r1**2,  r2**2,  r3**2,  r4**2 ],
-                                 [r1**3,  r2**3,  r3**3,  r4**3 ],
-                                 [r1**4,  r2**4,  r3**4,  r4**4 ],
-                                 [r1**5,  r2**5,  r3**5,  r4**5 ],
-                                 [r1**6,  r2**6,  r3**6,  r4**6 ],
-                                 [r1**7,  r2**7,  r3**7,  r4**7 ],
-                                 [r1**8,  r2**8,  r3**8,  r4**8 ],
-                                 [r1**9,  r2**9,  r3**9,  r4**9 ],
-                                 [r1**10, r2**10, r3**10, r4**10],
-                                 [r1**11, r2**11, r3**11, r4**11],
-                                 [r1**12, r2**12, r3**12, r4**12],
-                                 [r1**13, r2**13, r3**13, r4**13],
-                                 [r1**14, r2**14, r3**14, r4**14],
-                                 [r1**15, r2**15, r3**15, r4**15],
-                                 [r1**16, r2**16, r3**16, r4**16],
-                                 [r1**17, r2**17, r3**17, r4**17],
-                                 [r1**18, r2**18, r3**18, r4**18]])
+        data=[[r1**i,  r2**i,  r3**i,  r4**i] for i in range(1, 19)]
+        prices = DataFrame(index=dr, columns=tickers, data=data)
         dr2 = date_range(start='2015-1-21', end='2015-1-26')
         factor = DataFrame(index=dr2, columns=tickers,
                            data=[[3, 4, 2, 1], [3, 4, 2, 1], [3, 4, 2, 1],
@@ -438,8 +421,8 @@ class PerformanceTestCase(TestCase):
         avgrt = average_cumulative_return_by_quantile(quantile_factor, prices, before, after, demeaned)
         arrays = []
         for q in range(1, quantiles+1):
-            arrays.append( (q,'mean') )
-            arrays.append( (q,'std')  )
+            arrays.append((q, 'mean'))
+            arrays.append((q, 'std'))
         index = MultiIndex.from_tuples(arrays, names=['quantile', None])
         expected = DataFrame(index=index, columns=range(-before,after+1), data=expected_vals)
         assert_frame_equal(avgrt, expected)
@@ -476,22 +459,16 @@ class PerformanceTestCase(TestCase):
     def test_average_cumulative_return_by_quantile_2(self, before, after,
                                                    demeaned, quantiles,
                                                    expected_vals):
+        """
+        Test varying factor asset universe: at differnt dates there might be
+        different assets
+        """
         dr = date_range(start='2015-1-15', end='2015-1-25')
         dr.name = 'date'
         tickers = ['A', 'B', 'C', 'D', 'E', 'F']
         r1, r2, r3, r4 = (1.25, 1.50, 1.00, 0.50)
-        prices = DataFrame(index=dr, columns=tickers,
-                           data=[[r1**1,  r2**1,  r3**1,  r4**1,  r2**1,  r3**1 ],
-                                 [r1**2,  r2**2,  r3**2,  r4**2,  r2**2,  r3**2 ],
-                                 [r1**3,  r2**3,  r3**3,  r4**3,  r2**3,  r3**3 ],
-                                 [r1**4,  r2**4,  r3**4,  r4**4,  r2**4,  r3**4 ],
-                                 [r1**5,  r2**5,  r3**5,  r4**5,  r2**5,  r3**5 ],
-                                 [r1**6,  r2**6,  r3**6,  r4**6,  r2**6,  r3**6 ],
-                                 [r1**7,  r2**7,  r3**7,  r4**7,  r2**7,  r3**7 ],
-                                 [r1**8,  r2**8,  r3**8,  r4**8,  r2**8,  r3**8 ],
-                                 [r1**9,  r2**9,  r3**9,  r4**9,  r2**9,  r3**9 ],
-                                 [r1**10, r2**10, r3**10, r4**10, r2**10, r3**10],
-                                 [r1**11, r2**11, r3**11, r4**11, r2**11, r3**11]])
+        data=[[r1**i,  r2**i,  r3**i,  r4**i,  r2**i,  r3**i] for i in range(1, 12)]
+        prices = DataFrame(index=dr, columns=tickers, data=data)
         dr2 = date_range(start='2015-1-18', end='2015-1-21')
         factor = DataFrame(index=dr2, columns=tickers,
                            data=[[3, 4, 2, 1, nan, nan], [3, 4, 2, 1, nan, nan],
@@ -505,8 +482,8 @@ class PerformanceTestCase(TestCase):
         avgrt = average_cumulative_return_by_quantile(quantile_factor, prices, before, after, demeaned)
         arrays = []
         for q in range(1, quantiles+1):
-            arrays.append( (q,'mean') )
-            arrays.append( (q,'std')  )
+            arrays.append((q, 'mean'))
+            arrays.append((q, 'std'))
         index = MultiIndex.from_tuples(arrays, names=['quantile', None])
         expected = DataFrame(index=index, columns=range(-before,after+1), data=expected_vals)
         assert_frame_equal(avgrt, expected)

--- a/alphalens/tests/test_utils.py
+++ b/alphalens/tests/test_utils.py
@@ -117,7 +117,8 @@ class UtilsTestCase(TestCase):
         factor.index = factor.index.set_names(['date', 'asset'])
         factor.name = 'factor'
 
-        cmrt = common_start_returns(factor, prices, before, after, False, mean_by_date, demeaned)
+        cmrt = common_start_returns(factor, prices, before, after, False, mean_by_date,
+                                    factor if demeaned else None)
         cmrt = DataFrame( {'mean': cmrt.mean(axis=1), 'std': cmrt.std(axis=1)} )
         expected = DataFrame(index=range(-before, after+1), columns=['mean', 'std'], data=expected_vals)
         assert_frame_equal(cmrt, expected)


### PR DESCRIPTION
demeaning option returns wrong values if the factor asset universe
varies from date to date. The tests don't cover this scenario, so
this patch fix the issue and add a test case too.