### PR TITLE
bug fixes: using custom quantiles/bins might raise an exception

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -247,11 +247,13 @@ def quantize_factor(factor, quantiles=5, bins=None, by_group=False):
         optional a custom group.
     quantiles : int or sequence[float]
         Number of equal-sized quantile buckets to use in factor bucketing.
-        Alternately sequence of quantiles, e.g. [0, .10, .5, .90, 1.]
+        Alternately sequence of quantiles, allowing non-equal-sized buckets
+        e.g. [0, .10, .5, .90, 1.] or [.05, .5, .95]
         Only one of 'quantiles' or 'bins' can be not-None
     bins : int or sequence[float]
-        Number of equal-width bins to use in factor bucketing.
+        Number of equal-width (valuewise) bins to use in factor bucketing.
         Alternately sequence of bin edges allowing for non-uniform bin width
+        e.g. [-4, -2, -0.5, 0, 10]
         Only one of 'quantiles' or 'bins' can be not-None
     by_group : bool
         If True, compute quantile buckets separately for each group.
@@ -263,10 +265,11 @@ def quantize_factor(factor, quantiles=5, bins=None, by_group=False):
     """
 
     def quantile_calc(x, quantiles, bins):
-        if quantiles: 
+        if quantiles is not None: 
             return pd.qcut(x, quantiles, labels=False) + 1
-        else:
+        elif bins is not None:
             return pd.cut(x, bins, labels=False) + 1
+        raise ValueError('quantiles or bins should be provided')
 
     grouper = ['date', 'group'] if by_group else ['date']
 
@@ -276,7 +279,7 @@ def quantize_factor(factor, quantiles=5, bins=None, by_group=False):
                                               bins=bins)
     factor_quantile.name = 'quantile'
 
-    return factor_quantile
+    return factor_quantile.dropna()
 
 
 def mean_return_by_quantile(quantized_factor,

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -79,11 +79,13 @@ def create_factor_tear_sheet(factor,
         periods to compute forward returns on.
     quantiles : int or sequence[float]
         Number of equal-sized quantile buckets to use in factor bucketing.
-        Alternately sequence of quantiles, e.g. [0, .10, .5, .90, 1.]
+        Alternately sequence of quantiles, allowing non-equal-sized buckets
+        e.g. [0, .10, .5, .90, 1.] or [.05, .5, .95]
         Only one of 'quantiles' or 'bins' can be not-None
     bins : int or sequence[float]
-        Number of equal-width bins to use in factor bucketing.
+        Number of equal-width (valuewise) bins to use in factor bucketing.
         Alternately sequence of bin edges allowing for non-uniform bin width
+        e.g. [-4, -2, -0.5, 0, 10]
         Only one of 'quantiles' or 'bins' can be not-None
     filter_zscore : int or float
         Sets forward returns greater than X standard deviations
@@ -133,7 +135,7 @@ def create_factor_tear_sheet(factor,
                                            quantiles=quantiles,
                                            bins=bins)
 
-    num_quant = quantile_factor.max()
+    num_quant = int(quantile_factor.max())
 
     def compound_returns(period_ret):
         period = int(period_ret.name)

--- a/alphalens/tests/test_performance.py
+++ b/alphalens/tests/test_performance.py
@@ -146,8 +146,12 @@ class PerformanceTestCase(TestCase):
                             [1, 2, 3, 3, 3, 3, 2, 1]),
                            (factor, [0, .5, 1.], None, False,
                             [1, 1, 2, 2, 2, 2, 1, 1]),
+                           (factor, [.25, .5, .75], None, False,
+                            [nan, 1, 2, nan, nan, 2, 1, nan]),
                            (factor, [0, .5, 1.], None, True,
                             [1, 2, 1, 2, 2, 1, 2, 1]),
+                           (factor, [.5, 1.], None, True,
+                            [nan, 1, nan, 1, 1, nan, 1, nan]),
                            (factor, [0, 1.], None, True,
                             [1, 1, 1, 1, 1, 1, 1, 1]),
                            (factor, None, 4, False,
@@ -160,6 +164,8 @@ class PerformanceTestCase(TestCase):
                             [1, 3, 6, 8, 8, 6, 3, 1]),
                            (factor, None, [0, 1, 2, 3, 5], False,
                             [1, 2, 3, 4, 4, 3, 2, 1]),
+                           (factor, None, [1, 2, 3], False,
+                            [nan, 1, 2, nan, nan, 2, 1, nan]),
                            (factor, None, [0, 2, 5], False,
                             [1, 1, 2, 2, 2, 2, 1, 1]),
                            (factor, None, [0.5, 2.5, 4.5], False,
@@ -176,7 +182,7 @@ class PerformanceTestCase(TestCase):
                                            by_group=by_group)
         expected = Series(index=factor.index,
                           data=expected_vals,
-                          name='quantile')
+                          name='quantile').dropna()
         assert_series_equal(quantized_factor, expected)
 
     @parameterized.expand([([[1.0, 2.0, 3.0, 4.0],


### PR DESCRIPTION
I played a bit with the quantiles/bins tear sheet options and I found few bugs when I used a custom (non-uniform) quantiles/bins and when I selectively excluded certain quantiles/bins