### PR TITLE
Fix issue 124

### DIFF
--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -30,14 +30,13 @@ from functools import wraps
 DECIMAL_TO_BPS = 10000
 
 
-def plotting_context(func):
-    """Decorator to set plotting context during function call."""
+def customize(func):
+    """Decorator to set plotting context and axes style during function call."""
     @wraps(func)
     def call_w_context(*args, **kwargs):
         set_context = kwargs.pop('set_context', True)
         if set_context:
-            with context():
-                # sns.set_style("whitegrid")
+            with plotting_context(), axes_style():
                 sns.despine(left=True)
                 return func(*args, **kwargs)
         else:
@@ -45,8 +44,8 @@ def plotting_context(func):
     return call_w_context
 
 
-def context(context='notebook', font_scale=1.5, rc=None):
-    """Create pyfolio default plotting style context.
+def plotting_context(context='notebook', font_scale=1.5, rc=None):
+    """Create alphalens default plotting style context.
 
     Under the hood, calls and returns seaborn.plotting_context() with
     some custom settings. Usually you would use in a with-context.
@@ -59,9 +58,7 @@ def context(context='notebook', font_scale=1.5, rc=None):
         Scale font by factor font_scale.
     rc : dict, optional
         Config flags.
-        By default, {'lines.linewidth': 1.5,
-                     'axes.facecolor': '0.995',
-                     'figure.facecolor': '0.97'}
+        By default, {'lines.linewidth': 1.5}
         is being used and will be added to any
         rc passed in, unless explicitly overriden.
 
@@ -71,8 +68,8 @@ def context(context='notebook', font_scale=1.5, rc=None):
 
     Example
     -------
-    with pyfolio.plotting.context(font_scale=2):
-        pyfolio.create_full_tear_sheet()
+    with alphalens.plotting.plotting_context(font_scale=2):
+        alphalens.create_factor_tear_sheet()
 
     See also
     --------
@@ -82,17 +79,52 @@ def context(context='notebook', font_scale=1.5, rc=None):
     if rc is None:
         rc = {}
 
-    rc_default = {'lines.linewidth': 1.5,
-                  # 'axes.facecolor': '0.995',
-                  'axes.facecolor': 'white',
-                  'axes.edgecolor': '1',
-                  'figure.facecolor': '0.97'}
+    rc_default = {'lines.linewidth': 1.5}
 
     # Add defaults if they do not exist
     for name, val in rc_default.items():
         rc.setdefault(name, val)
 
     return sns.plotting_context(context=context, font_scale=font_scale, rc=rc)
+
+
+def axes_style(style='darkgrid', rc=None):
+    """Create alphalens default axes style context.
+
+    Under the hood, calls and returns seaborn.axes_style() with
+    some custom settings. Usually you would use in a with-context.
+
+    Parameters
+    ----------
+    style : str, optional
+        Name of seaborn style.
+    rc : dict, optional
+        Config flags.
+
+    Returns
+    -------
+    seaborn plotting context
+
+    Example
+    -------
+    with alphalens.plotting.axes_style(style='whitegrid'):
+        alphalens.create_factor_tear_sheet()
+
+    See also
+    --------
+    For more information, see seaborn.plotting_context().
+
+    """
+    if rc is None:
+        rc = {}
+
+    rc_default = { }
+
+    # Add defaults if they do not exist
+    for name, val in rc_default.items():
+        rc.setdefault(name, val)
+
+    return sns.axes_style(style=style, rc=rc)
 
 
 def summary_stats(factor,

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 
-@plotting.plotting_context
+@plotting.customize
 def create_factor_tear_sheet(factor,
                              prices,
                              groupby=None,


### PR DESCRIPTION
Switched to 'darkgrid' axes style to improve readability, issue #124 

Also this fix another issue. The plotting.context function tries to set 'axes.facecolor' and 'figure.facecolor' properties using seaborn.plotting_context(), but that cannot work. seaborn.plotting_context() is intended to control the scale of plot elements while seaborn.axes_style() fucntion should be used for the style. So a combination of the two is required to have full control of the plotting properties. See http://seaborn.pydata.org/tutorial/aesthetics.html