### PR TITLE
Mark notebooks binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@
 build/
 docs/build/
 .ipynb_checkpoints
+
+# Tox puts virtualenvs here by default.
+.tox/
+
+# coverage.py outputs.
+cover
+.coverage
+
+# Intermediate outputs from building distributions for PyPI.
+dist
+*.egg-info/
+
+# Emacs temp files.
+*~

--- a/alphalens/examples/.gitattributes
+++ b/alphalens/examples/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb binary


### PR DESCRIPTION
Mark notebook files as binary.

This prevents the embedded images in .ipynb files from destroying commands like `git grep` and `git diff`.

Also added a bunch of files to `.gitignore`.