### PR TITLE
BUG: plot_cumulative_returns_by_quantile crashes with quantiles=1

### DIFF
--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -768,11 +768,8 @@ def plot_cumulative_returns_by_quantile(quantile_returns, period=1, ax=None):
 
     cum_ret = ret_wide.add(1).cumprod()
     cum_ret = cum_ret.loc[:, ::-1]
-    num_quant = len(cum_ret.columns)
 
-    colors = cm.RdYlGn_r(np.linspace(0, 1, num_quant))
-
-    cum_ret.plot(lw=2, ax=ax, color=colors)
+    cum_ret.plot(lw=2, ax=ax, cmap=cm.RdYlGn_r)
     ax.legend()
     ymin, ymax = cum_ret.min().min(), cum_ret.max().max()
     ax.set(ylabel='Log Cumulative Returns',


### PR DESCRIPTION
plot_cumulative_returns_by_quantile generates the following error when  quantiles=1


```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
/home/luca/.local/lib/python2.7/site-packages/IPython/core/formatters.pyc in __call__(self, obj)
    305                 pass
    306             else:
--> 307                 return printer(obj)
    308             # Finally look for special method names
    309             method = get_real_method(obj, self.print_method)

/home/luca/.local/lib/python2.7/site-packages/IPython/core/pylabtools.pyc in <lambda>(fig)
    238 
    239     if 'png' in formats:
--> 240         png_formatter.for_type(Figure, lambda fig: print_figure(fig, 'png', **kwargs))
    241     if 'retina' in formats or 'png2x' in formats:
    242         png_formatter.for_type(Figure, lambda fig: retina_figure(fig, **kwargs))

/home/luca/.local/lib/python2.7/site-packages/IPython/core/pylabtools.pyc in print_figure(fig, fmt, bbox_inches, **kwargs)
    122 
    123     bytes_io = BytesIO()
--> 124     fig.canvas.print_figure(bytes_io, **kw)
    125     data = bytes_io.getvalue()
    126     if fmt == 'svg':

/home/luca/.local/lib/python2.7/site-packages/matplotlib/backend_bases.pyc in print_figure(self, filename, dpi, facecolor, edgecolor, orientation, format, **kwargs)
   2178                     orientation=orientation,
   2179                     dryrun=True,
-> 2180                     **kwargs)
   2181                 renderer = self.figure._cachedRenderer
   2182                 bbox_inches = self.figure.get_tightbbox(renderer)

/home/luca/.local/lib/python2.7/site-packages/matplotlib/backends/backend_agg.pyc in print_png(self, filename_or_obj, *args, **kwargs)
    525 
    526     def print_png(self, filename_or_obj, *args, **kwargs):
--> 527         FigureCanvasAgg.draw(self)
    528         renderer = self.get_renderer()
    529         original_dpi = renderer.dpi

/home/luca/.local/lib/python2.7/site-packages/matplotlib/backends/backend_agg.pyc in draw(self)
    472 
    473         try:
--> 474             self.figure.draw(self.renderer)
    475         finally:
    476             RendererAgg.lock.release()

/home/luca/.local/lib/python2.7/site-packages/matplotlib/artist.pyc in draw_wrapper(artist, renderer, *args, **kwargs)
     60     def draw_wrapper(artist, renderer, *args, **kwargs):
     61         before(artist, renderer)
---> 62         draw(artist, renderer, *args, **kwargs)
     63         after(artist, renderer)
     64 

/home/luca/.local/lib/python2.7/site-packages/matplotlib/figure.pyc in draw(self, renderer)
   1157         dsu.sort(key=itemgetter(0))
   1158         for zorder, a, func, args in dsu:
-> 1159             func(*args)
   1160 
   1161         renderer.close_group('figure')

/home/luca/.local/lib/python2.7/site-packages/matplotlib/artist.pyc in draw_wrapper(artist, renderer, *args, **kwargs)
     60     def draw_wrapper(artist, renderer, *args, **kwargs):
     61         before(artist, renderer)
---> 62         draw(artist, renderer, *args, **kwargs)
     63         after(artist, renderer)
     64 

/home/luca/.local/lib/python2.7/site-packages/matplotlib/axes/_base.pyc in draw(self, renderer, inframe)
   2317 
   2318         for zorder, a in dsu:
-> 2319             a.draw(renderer)
   2320 
   2321         renderer.close_group('axes')

/home/luca/.local/lib/python2.7/site-packages/matplotlib/artist.pyc in draw_wrapper(artist, renderer, *args, **kwargs)
     60     def draw_wrapper(artist, renderer, *args, **kwargs):
     61         before(artist, renderer)
---> 62         draw(artist, renderer, *args, **kwargs)
     63         after(artist, renderer)
     64 

/home/luca/.local/lib/python2.7/site-packages/matplotlib/lines.pyc in draw(self, renderer)
    750                 self._set_gc_clip(gc)
    751 
--> 752                 ln_color_rgba = self._get_rgba_ln_color()
    753                 gc.set_foreground(ln_color_rgba, isRGBA=True)
    754                 gc.set_alpha(ln_color_rgba[3])

/home/luca/.local/lib/python2.7/site-packages/matplotlib/lines.pyc in _get_rgba_ln_color(self, alt)
   1288 
   1289     def _get_rgba_ln_color(self, alt=False):
-> 1290         return colorConverter.to_rgba(self._color, self._alpha)
   1291 
   1292     # some aliases....

/home/luca/.local/lib/python2.7/site-packages/matplotlib/colors.pyc in to_rgba(self, arg, alpha)
    374         except (TypeError, ValueError) as exc:
    375             raise ValueError(
--> 376                 'to_rgba: Invalid rgba arg "%s"\n%s' % (str(arg), exc))
    377 
    378     def to_rgba_array(self, c, alpha=None):

ValueError: to_rgba: Invalid rgba arg "[[ 0.          0.40784314  0.21568628  1.        ]]"
length of rgba sequence should be either 3 or 4

<matplotlib.figure.Figure at 0x7fd839bafa50>

````


