### PR TITLE
Daily compound returns analysis

### DIFF
--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -175,7 +175,7 @@ def create_returns_tear_sheet(factor_data, long_short=True, by_group=False):
     vertical_sections = 2 + fr_cols * 3
     gf = GridFigure(rows=vertical_sections, cols=1)
 
-    plotting.plot_returns_table(alpha_beta, mean_ret_quantile, mean_ret_spread_quant)
+    plotting.plot_returns_table(alpha_beta, mean_compret_quantile, mean_ret_spread_quant)
 
     plotting.plot_quantile_returns_bar(mean_compret_quantile,
                                        by_group=False,

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -101,7 +101,7 @@ def create_summary_tear_sheet(factor_data, long_short=True):
 
     plotting.plot_quantile_statistics_table(factor_data)
 
-    plotting.plot_returns_table(alpha_beta, mean_ret_quantile, mean_ret_spread_quant)
+    plotting.plot_returns_table(alpha_beta, mean_compret_quantile, mean_ret_spread_quant)
 
     plotting.plot_quantile_returns_bar(mean_compret_quantile,
                                        by_group=False,


### PR DESCRIPTION
In response to Issue #154, I modified the Returns Analysis table so that the "Mean Period Wise Return Top (Bottom) Quantile" rows displayed daily (one-period) returns, so that it is consistent with the "Mean Period Wise Spread" row. 

![image](https://user-images.githubusercontent.com/28760724/27254883-0b25f696-5360-11e7-9195-405bd0d0d96f.png)
