### PR TITLE
Fix std se conversion

### DIFF
--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -84,7 +84,7 @@ def create_summary_tear_sheet(factor_data, long_short=True):
 
     mean_compret_quant_daily = mean_ret_quant_daily.apply(utils.rate_of_return,
                                                           axis=0)
-    compstd_quant_daily = std_quant_daily.apply(utils.rate_of_return, axis=0)
+    compstd_quant_daily = std_quant_daily.apply(utils.std_conversion, axis=0)
 
     alpha_beta = perf.factor_alpha_beta(factor_data)
 
@@ -161,7 +161,7 @@ def create_returns_tear_sheet(factor_data, long_short=True, by_group=False):
                                                                          demeaned=long_short)
 
     mean_compret_quant_daily = mean_ret_quant_daily.apply(utils.rate_of_return, axis=0)
-    compstd_quant_daily = std_quant_daily.apply(utils.rate_of_return, axis=0)
+    compstd_quant_daily = std_quant_daily.apply(utils.std_conversion, axis=0)
 
     alpha_beta = perf.factor_alpha_beta(factor_data)
 

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -445,6 +445,18 @@ def rate_of_return(period_ret):
 def std_conversion(period_std):
     """
     1-period standard deviation (or standard error) approximation
+    
+    Parameters
+    ----------
+    period_std: pd.DataFrame
+        DataFrame containing standard deviation or standard error values
+        with column headings representing the return period.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame in same format as input but with one-period
+        standard deviation/error values.
     """
     period_len = period_std.name
     return period_std / np.sqrt(period_len)

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -442,5 +442,13 @@ def rate_of_return(period_ret):
     return period_ret.add(1).pow(1./period_ret.name).sub(1)
 
 
+def std_conversion(period_std):
+    """
+    1-period standard deviation (or standard error) approximation
+    """
+    period_len = period_std.name
+    return period_std / np.sqrt(period_len)
+
+
 def get_forward_returns_columns(columns):
     return columns[columns.astype('str').str.isdigit()]


### PR DESCRIPTION
Correct the formula/function used to convert the standard error in the tear sheet to a one-period standard error. This is done by creating a new function in the utils module.

Issue #155