### PR TITLE
Improved "binning by group" option docstrings

### DIFF
--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -294,7 +294,7 @@ def get_clean_factor_and_forward_returns(factor,
         entire time period of the passed factor data.
     binning_by_group : bool
         If True, compute bin or quantile buckets separately for each group.
-        This is useful when the factor values range vary considerably 
+        This is useful when the factor values range vary considerably
         across gorups so that it is wise to make the binning group relative.
     quantiles : int or sequence[float]
         Number of equal-sized quantile buckets to use in factor bucketing.

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -224,7 +224,7 @@ def print_table(table, name=None, fmt=None):
 def get_clean_factor_and_forward_returns(factor,
                                          prices,
                                          groupby=None,
-                                         by_group=False,
+                                         binning_by_group=False,
                                          quantiles=5,
                                          bins=None,
                                          periods=(1, 5, 10),
@@ -292,8 +292,10 @@ def get_clean_factor_and_forward_returns(factor,
         a dict of asset to group mappings. If a dict is passed,
         it is assumed that group mappings are unchanged for the
         entire time period of the passed factor data.
-    by_group : bool
-        If True, compute statistics separately for each group.
+    binning_by_group : bool
+        If True, compute bin or quantile buckets separately for each group.
+        This is useful when the factor values range vary considerably 
+        across gorups so that it is wise to make the binning group relative.
     quantiles : int or sequence[float]
         Number of equal-sized quantile buckets to use in factor bucketing.
         Alternately sequence of quantiles, allowing non-equal-sized buckets
@@ -385,7 +387,7 @@ def get_clean_factor_and_forward_returns(factor,
     merged_data['factor_quantile'] = quantize_factor(merged_data,
                                                      quantiles,
                                                      bins,
-                                                     by_group)
+                                                     binning_by_group)
 
     merged_data = merged_data.dropna()
 


### PR DESCRIPTION
The current meaning of 'by_group' option
(untils.get_clean_factor_and_forward_returns functions)  is a little obscure so the docstring was improved.

Also the name 'by_group' is used elsewhere in the API with the meaning of breaking the output in multiple results, one per group,so  the variable was renamed  to 'binning_by_group'