### PR TITLE
Added support for group neutral factor analysis

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -24,7 +24,6 @@ from . import utils
 
 
 def factor_information_coefficient(factor_data,
-                                   group_adjust=False,
                                    by_group=False):
     """
     Computes the Spearman Rank Correlation based Information Coefficient (IC)
@@ -39,8 +38,6 @@ def factor_information_coefficient(factor_data,
         each period, the factor quantile/bin that factor value belongs to, and
         (optionally) the group the asset belongs to.
         - See full explanation in utils.get_clean_factor_and_forward_returns
-    group_adjust : bool
-        Demean forward returns by group before computing IC.
     by_group : bool
         If True, compute period wise IC separately for each group.
 
@@ -61,9 +58,6 @@ def factor_information_coefficient(factor_data,
 
     grouper = [factor_data.index.get_level_values('date')]
 
-    if group_adjust:
-        factor_data = utils.demean_forward_returns(factor_data,
-                                                   grouper + ['group'])
     if by_group:
         grouper.append('group')
 
@@ -74,7 +68,6 @@ def factor_information_coefficient(factor_data,
 
 
 def mean_information_coefficient(factor_data,
-                                 group_adjust=False,
                                  by_group=False,
                                  by_time=None):
     """
@@ -92,8 +85,6 @@ def mean_information_coefficient(factor_data,
         each period, the factor quantile/bin that factor value belongs to, and
         (optionally) the group the asset belongs to.
         - See full explanation in utils.get_clean_factor_and_forward_returns
-    group_adjust : bool
-        Demean forward returns by group before computing IC.
     by_group : bool
         If True, take the mean IC for each group.
     by_time : str (pd time_rule), optional
@@ -108,7 +99,7 @@ def mean_information_coefficient(factor_data,
         forward price movement windows.
     """
 
-    ic = factor_information_coefficient(factor_data, group_adjust, by_group)
+    ic = factor_information_coefficient(factor_data, by_group)
 
     grouper = []
     if by_time is not None:

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -269,7 +269,6 @@ def create_returns_tear_sheet(factor_data,
 
 @plotting.customize
 def create_information_tear_sheet(factor_data,
-                                  group_neutral=False,
                                   by_group=False):
     """
     Creates a tear sheet for information analysis of a factor.
@@ -282,13 +281,11 @@ def create_information_tear_sheet(factor_data,
         each period, the factor quantile/bin that factor value belongs to, and
         (optionally) the group the asset belongs to.
         - See full explanation in utils.get_clean_factor_and_forward_returns
-    group_neutral : bool
-        Demean forward returns by group before computing IC.
     by_group : bool
         If True, display graphs separately for each group.
     """
 
-    ic = perf.factor_information_coefficient(factor_data, group_neutral)
+    ic = perf.factor_information_coefficient(factor_data)
 
     plotting.plot_information_table(ic)
 
@@ -309,7 +306,6 @@ def create_information_tear_sheet(factor_data,
 
         mean_monthly_ic = \
             perf.mean_information_coefficient(factor_data,
-                                              group_adjust=group_neutral,
                                               by_group=False,
                                               by_time="M")
         ax_monthly_ic_heatmap = [gf.next_cell() for x in range(fr_cols)]
@@ -319,7 +315,6 @@ def create_information_tear_sheet(factor_data,
     if by_group:
         mean_group_ic = \
             perf.mean_information_coefficient(factor_data,
-                                              group_adjust=group_neutral,
                                               by_group=True)
 
         plotting.plot_ic_by_group(mean_group_ic, ax=gf.next_row())
@@ -397,8 +392,6 @@ def create_full_tear_sheet(factor_data,
         Should this computation happen on a group neutral portfolio?
         - See tears.create_returns_tear_sheet for details on how this flag
         affects returns analysis
-        - See tears.create_information_tear_sheet for details on how this
-        flag affects information analysis
     by_group : bool
         If True, display graphs separately for each group.
     """
@@ -410,7 +403,6 @@ def create_full_tear_sheet(factor_data,
                               by_group,
                               set_context=False)
     create_information_tear_sheet(factor_data,
-                                  group_neutral,
                                   by_group,
                                   set_context=False)
     create_turnover_tear_sheet(factor_data, set_context=False)

--- a/alphalens/tests/test_performance.py
+++ b/alphalens/tests/test_performance.py
@@ -57,23 +57,17 @@ class PerformanceTestCase(TestCase):
                                   dtype="category")
 
     @parameterized.expand([(factor_data, [4, 3, 2, 1, 1, 2, 3, 4],
-                            False, False,
+                            False,
                             dr,
                             [-1., -1.],
                             ),
                            (factor_data, [1, 2, 3, 4, 4, 3, 2, 1],
-                            False, False,
+                            False,
                             dr,
                             [1., 1.],
                             ),
                            (factor_data, [1, 2, 3, 4, 4, 3, 2, 1],
-                            False, True,
-                            MultiIndex.from_product(
-                                [dr, [1, 2]], names=['date', 'group']),
-                            [1., 1., 1., 1.],
-                            ),
-                           (factor_data, [1, 2, 3, 4, 4, 3, 2, 1],
-                            True, True,
+                            True,
                             MultiIndex.from_product(
                                 [dr, [1, 2]], names=['date', 'group']),
                             [1., 1., 1., 1.],
@@ -81,7 +75,6 @@ class PerformanceTestCase(TestCase):
     def test_information_coefficient(self,
                                      factor_data,
                                      forward_returns,
-                                     group_adjust,
                                      by_group,
                                      expected_ix,
                                      expected_ic_val):
@@ -90,7 +83,6 @@ class PerformanceTestCase(TestCase):
                                 data=forward_returns)
 
         ic = factor_information_coefficient(factor_data=factor_data,
-                                            group_adjust=group_adjust,
                                             by_group=by_group)
 
         expected_ic_df = DataFrame(index=expected_ix,
@@ -102,13 +94,11 @@ class PerformanceTestCase(TestCase):
     @parameterized.expand([(factor_data,
                             [4, 3, 2, 1, 1, 2, 3, 4],
                             False,
-                            False,
                             'D',
                             dr,
                             [-1., -1.]),
                            (factor_data,
                             [1, 2, 3, 4, 4, 3, 2, 1],
-                            False,
                             False,
                             'W',
                             DatetimeIndex(['2015-01-04'],
@@ -117,14 +107,12 @@ class PerformanceTestCase(TestCase):
                             [1.]),
                            (factor_data,
                             [1, 2, 3, 4, 4, 3, 2, 1],
-                            False,
                             True,
                             None,
                             Int64Index([1, 2], name='group'),
                             [1., 1.]),
                            (factor_data,
                             [1, 2, 3, 4, 4, 3, 2, 1],
-                            False,
                             True,
                             'W',
                             MultiIndex.from_product(
@@ -136,7 +124,6 @@ class PerformanceTestCase(TestCase):
     def test_mean_information_coefficient(self,
                                           factor_data,
                                           forward_returns,
-                                          group_adjust,
                                           by_group,
                                           by_time,
                                           expected_ix,
@@ -146,7 +133,6 @@ class PerformanceTestCase(TestCase):
                                 data=forward_returns)
 
         ic = mean_information_coefficient(factor_data,
-                                          group_adjust=group_adjust,
                                           by_group=by_group,
                                           by_time=by_time)
 

--- a/alphalens/tests/test_performance.py
+++ b/alphalens/tests/test_performance.py
@@ -220,7 +220,7 @@ class PerformanceTestCase(TestCase):
     def test_factor_returns(self,
                             factor_vals,
                             fwd_return_vals,
-                            group_neutral,
+                            group_adjust,
                             expected_vals):
 
         factor_data = self.factor_data.copy()
@@ -228,8 +228,8 @@ class PerformanceTestCase(TestCase):
         factor_data['factor'] = factor_vals
 
         factor_returns_s = factor_returns(factor_data=factor_data,
-                                          long_short=True,
-                                          group_neutral=group_neutral)
+                                          demeaned=True,
+                                          group_adjust=group_adjust)
 
         expected = DataFrame(
             index=self.dr,
@@ -372,20 +372,19 @@ class PerformanceTestCase(TestCase):
         dr2.name = 'date'
         factor = DataFrame(
             index=dr2, columns=tickers, data=[
-                [
-                    3, 4, 2, 1], [
-                    3, 4, 2, 1], [
-                    3, 4, 2, 1], [
-                        3, 4, 2, 1], [
-                            3, 4, 2, 1], [
-                                3, 4, 2, 1]]).stack()
+                [3, 4, 2, 1],
+                [3, 4, 2, 1],
+                [3, 4, 2, 1],
+                [3, 4, 2, 1],
+                [3, 4, 2, 1],
+                [3, 4, 2, 1]]).stack()
 
         factor_data = get_clean_factor_and_forward_returns(
             factor, prices, quantiles=quantiles, periods=range(
                 0, after + 1), filter_zscore=False)
 
         avgrt = average_cumulative_return_by_quantile(
-            factor_data['factor_quantile'], prices, before, after, demeaned)
+            factor_data, prices, before, after, demeaned)
         arrays = []
         for q in range(1, quantiles + 1):
             arrays.append((q, 'mean'))
@@ -451,7 +450,7 @@ class PerformanceTestCase(TestCase):
                 0, after + 1), filter_zscore=False)
 
         avgrt = average_cumulative_return_by_quantile(
-            factor_data['factor_quantile'], prices, before, after, demeaned)
+            factor_data, prices, before, after, demeaned)
         arrays = []
         for q in range(1, quantiles + 1):
             arrays.append((q, 'mean'))

--- a/alphalens/tests/test_tears.py
+++ b/alphalens/tests/test_tears.py
@@ -92,8 +92,7 @@ class PerformanceTestCase(TestCase):
             periods=periods,
             filter_zscore=filter_zscore)
 
-        create_information_tear_sheet(
-            factor_data, group_neutral=False, by_group=False)
+        create_information_tear_sheet(factor_data, by_group=False)
 
     @parameterized.expand([(2, (2, 3, 6), True),
                            (4, (1, 2, 3, 7), False)])

--- a/alphalens/tests/test_tears.py
+++ b/alphalens/tests/test_tears.py
@@ -56,17 +56,15 @@ class PerformanceTestCase(TestCase):
                              [3, 4, 2, 1, nan, nan], [3, 4, 2, 1, nan, nan],
                              [3, nan, nan, 1, 4, 2], [3, nan, nan, 1, 4, 2]]) \
         .stack()
+    factor_groups = {'A': 1, 'B': 2, 'C': 1, 'D': 2, 'E': 1, 'F': 2}
 
-    @parameterized.expand([(2, (1, 5, 10), False, False),
-                           (3, (2, 4, 6), True, False),
-                           (4, (1, 8), False, True),
-                           (4, (1, 2, 3, 7), True, True)])
+    @parameterized.expand([(2, (1, 5, 10), False),
+                           (3, (2, 4, 6), True)])
     def test_create_returns_tear_sheet(
             self,
             quantiles,
             periods,
-            filter_zscore,
-            long_short):
+            filter_zscore):
         """
         Test no exceptions are thrown
         """
@@ -78,14 +76,12 @@ class PerformanceTestCase(TestCase):
             filter_zscore=filter_zscore)
 
         create_returns_tear_sheet(
-            factor_data, long_short=long_short, by_group=False)
+            factor_data, long_short=False, group_neutral=False, by_group=False)
 
-    @parameterized.expand([(1, (1, 5, 10), False, False),
-                           (3, (2, 4, 6), False, True),
-                           (2, (1, 8), True, False),
-                           (4, (1, 2, 3, 7), True, True)])
+    @parameterized.expand([(1, (1, 5, 10), False),
+                           (4, (1, 2, 3, 7), True)])
     def test_create_information_tear_sheet(
-            self, quantiles, periods, filter_zscore, long_short):
+            self, quantiles, periods, filter_zscore):
         """
         Test no exceptions are thrown
         """
@@ -97,18 +93,15 @@ class PerformanceTestCase(TestCase):
             filter_zscore=filter_zscore)
 
         create_information_tear_sheet(
-            factor_data, group_adjust=False, by_group=False)
+            factor_data, group_neutral=False, by_group=False)
 
-    @parameterized.expand([(2, (2, 3, 6), True, True),
-                           (3, (1, 2, 3), True, False),
-                           (4, (3, 7), False, True),
-                           (4, (1, 2, 3, 7), False, False)])
+    @parameterized.expand([(2, (2, 3, 6), True),
+                           (4, (1, 2, 3, 7), False)])
     def test_create_turnover_tear_sheet(
             self,
             quantiles,
             periods,
-            filter_zscore,
-            long_short):
+            filter_zscore):
         """
         Test no exceptions are thrown
         """
@@ -121,16 +114,13 @@ class PerformanceTestCase(TestCase):
 
         create_turnover_tear_sheet(factor_data)
 
-    @parameterized.expand([(2, (1, 5, 10), False, False),
-                           (1, (2, 4, 6), True, True),
-                           (4, (1, 8), False, True),
-                           (3, (1, 2, 3, 7), True, False)])
+    @parameterized.expand([(2, (1, 5, 10), False),
+                           (3, (1, 2, 3, 7), True)])
     def test_create_summary_tear_sheet(
             self,
             quantiles,
             periods,
-            filter_zscore,
-            long_short):
+            filter_zscore):
         """
         Test no exceptions are thrown
         """
@@ -141,61 +131,76 @@ class PerformanceTestCase(TestCase):
             periods=periods,
             filter_zscore=filter_zscore)
 
-        create_summary_tear_sheet(factor_data, long_short=long_short)
+        create_summary_tear_sheet(
+            factor_data, long_short=True, group_neutral=False)
+        create_summary_tear_sheet(
+            factor_data, long_short=False, group_neutral=False)
 
-    @parameterized.expand([(2, (1, 5, 10), False, False),
-                           (3, (2, 4, 6), True, False),
-                           (4, (1, 8), False, True),
-                           (4, (1, 2, 3, 7), True, True)])
+    @parameterized.expand([(2, (1, 5, 10), False),
+                           (3, (2, 4, 6), True),
+                           (4, (1, 8), False),
+                           (4, (1, 2, 3, 7), True)])
     def test_create_full_tear_sheet(
             self,
             quantiles,
             periods,
-            filter_zscore,
-            long_short):
+            filter_zscore):
         """
         Test no exceptions are thrown
         """
         factor_data = get_clean_factor_and_forward_returns(
             self.factor,
             self.prices,
+            groupby=self.factor_groups,
             quantiles=quantiles,
             periods=periods,
             filter_zscore=filter_zscore)
 
-        create_full_tear_sheet(
-            factor_data,
-            long_short=long_short,
-            group_adjust=False,
-            by_group=False)
+        create_full_tear_sheet(factor_data, long_short=False,
+                               group_neutral=False, by_group=False)
+        create_full_tear_sheet(factor_data, long_short=True,
+                               group_neutral=False, by_group=True)
+        create_full_tear_sheet(factor_data, long_short=True,
+                               group_neutral=True, by_group=True)
 
-    @parameterized.expand([(2, (1, 5, 10), False, False),
-                           (3, (2, 4, 6), True, False),
-                           (4, (3, 4), False, True),
-                           (1, (2, 3, 6, 9), True, True)])
+    @parameterized.expand([(2, (1, 5, 10), False),
+                           (3, (2, 4, 6), True),
+                           (4, (3, 4), False),
+                           (1, (2, 3, 6, 9), True)])
     def test_create_event_returns_tear_sheet(
-            self, quantiles, periods, filter_zscore, long_short):
+            self, quantiles, periods, filter_zscore):
         """
         Test no exceptions are thrown
         """
         factor_data = get_clean_factor_and_forward_returns(
             self.factor,
             self.prices,
+            groupby=self.factor_groups,
             quantiles=quantiles,
             periods=periods,
             filter_zscore=filter_zscore)
 
         create_event_returns_tear_sheet(factor_data, self.prices, avgretplot=(
-            5, 11), long_short=long_short, by_group=False)
+            5, 11), long_short=False, group_neutral=False, by_group=False)
+        create_event_returns_tear_sheet(factor_data, self.prices, avgretplot=(
+            5, 11), long_short=True, group_neutral=False, by_group=False)
+        create_event_returns_tear_sheet(factor_data, self.prices, avgretplot=(
+            5, 11), long_short=False, group_neutral=True, by_group=False)
+        create_event_returns_tear_sheet(factor_data, self.prices, avgretplot=(
+            5, 11), long_short=False, group_neutral=False, by_group=True)
+        create_event_returns_tear_sheet(factor_data, self.prices, avgretplot=(
+            5, 11), long_short=True, group_neutral=False, by_group=True)
+        create_event_returns_tear_sheet(factor_data, self.prices, avgretplot=(
+            5, 11), long_short=False, group_neutral=True, by_group=True)
 
-    @parameterized.expand([((6, 8), False, False),
-                           ((6, 8), False, True),
-                           ((6, 3), True, False),
-                           ((6, 3), True, True),
-                           ((0, 3), False, True),
-                           ((3, 0), True, True)])
+    @parameterized.expand([((6, 8), False),
+                           ((6, 8), False),
+                           ((6, 3), True),
+                           ((6, 3), True),
+                           ((0, 3), False),
+                           ((3, 0), True)])
     def test_create_event_study_tear_sheet(
-            self, avgretplot, filter_zscore, long_short):
+            self, avgretplot, filter_zscore):
         """
         Test no exceptions are thrown
         """

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -261,7 +261,7 @@ def print_table(table, name=None, fmt=None):
 def get_clean_factor_and_forward_returns(factor,
                                          prices,
                                          groupby=None,
-                                         by_group=False,
+                                         binning_by_group=False,
                                          quantiles=5,
                                          bins=None,
                                          periods=(1, 5, 10),
@@ -330,8 +330,10 @@ def get_clean_factor_and_forward_returns(factor,
         a dict of asset to group mappings. If a dict is passed,
         it is assumed that group mappings are unchanged for the
         entire time period of the passed factor data.
-    by_group : bool
-        If True, compute statistics separately for each group.
+    binning_by_group : bool
+        If True, compute bin or quantile buckets separately for each group.
+        This is useful when the factor values range vary considerably
+        across gorups so that it is wise to make the binning group relative.
     quantiles : int or sequence[float]
         Number of equal-sized quantile buckets to use in factor bucketing.
         Alternately sequence of quantiles, allowing non-equal-sized buckets
@@ -435,7 +437,7 @@ def get_clean_factor_and_forward_returns(factor,
 
     no_raise = False if max_loss == 0 else True
     merged_data['factor_quantile'] = \
-        quantize_factor(merged_data, quantiles, bins, by_group, no_raise)
+        quantize_factor(merged_data, quantiles, bins, binning_by_group, no_raise)
 
     merged_data = merged_data.dropna()
 

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -438,8 +438,11 @@ def get_clean_factor_and_forward_returns(factor,
     fwdret_amount = float(len(merged_data.index))
 
     no_raise = False if max_loss == 0 else True
-    merged_data['factor_quantile'] = \
-        quantize_factor(merged_data, quantiles, bins, binning_by_group, no_raise)
+    merged_data['factor_quantile'] = quantize_factor(merged_data,
+                                                     quantiles,
+                                                     bins,
+                                                     binning_by_group,
+                                                     no_raise)
 
     merged_data = merged_data.dropna()
 

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -331,9 +331,11 @@ def get_clean_factor_and_forward_returns(factor,
         it is assumed that group mappings are unchanged for the
         entire time period of the passed factor data.
     binning_by_group : bool
-        If True, compute bin or quantile buckets separately for each group.
+        If True, compute quantile buckets separately for each group.
         This is useful when the factor values range vary considerably
         across gorups so that it is wise to make the binning group relative.
+        You should probably enable this if the factor is intended
+        to be analyzed for a group neutral portfolio
     quantiles : int or sequence[float]
         Number of equal-sized quantile buckets to use in factor bucketing.
         Alternately sequence of quantiles, allowing non-equal-sized buckets
@@ -466,7 +468,7 @@ def common_start_returns(factor,
                          after,
                          cumulative=False,
                          mean_by_date=False,
-                         demean=None):
+                         demean_by=None):
     """
     A date and equity pair is extracted from each index row in the factor
     dataframe and for each of these pairs a return series is built starting
@@ -493,11 +495,11 @@ def common_start_returns(factor,
     mean_by_date: bool, optional
         If True, compute mean returns for each date and return that
         instead of a return series for each asset
-    demean: pd.DataFrame, optional
+    demean_by: pd.DataFrame, optional
         DataFrame with at least date and equity as index, the columns are
-        irrelevant. For each date a list of equities is extracted from 'demean'
-        index and used as universe to compute demeaned mean returns (long short
-        portfolio)
+        irrelevant. For each date a list of equities is extracted from
+        'demean_by' index and used as universe to compute demeaned mean
+        returns (long short portfolio)
 
     Returns
     -------
@@ -527,8 +529,8 @@ def common_start_returns(factor,
                            len(returns.index))
 
         equities_slice = set(equities)
-        if demean is not None:
-            demean_equities = demean.loc[timestamp] \
+        if demean_by is not None:
+            demean_equities = demean_by.loc[timestamp] \
                 .index.get_level_values('asset')
             equities_slice |= set(demean_equities)
 
@@ -540,7 +542,7 @@ def common_start_returns(factor,
         if cumulative:
             series = (series / series.loc[0, :]) - 1
 
-        if demean is not None:
+        if demean_by is not None:
             mean = series.loc[:, demean_equities].mean(axis=1)
             series = series.loc[:, equities]
             series = series.sub(mean, axis=0)


### PR DESCRIPTION
I am working on a sector neutral factor and I discovered that Alphalens analysis on a group neutral factor is currently limited. With group neutral factor I mean a factor intended to rank stocks across the same group, so that it makes sense to compare performance of top vs bottom stocks in the same group but it doesn't make sense to compare performance of a stock in one group with performance of another group.

The main shortcoming is the return analysis: as there is no way to demean the returns by group,  the statistics shown are of little use. Also when the plots are broken down by group, the results are not useful either as there are 2 bugs:
- API documentation claims that perf.mean_return_by_quantile was performing is performing the demeaning at group level when splitting the plots by group, but even in that case it is not true
- The same goes for perf.mean_information_coefficient

Also changed the API arguments names in a consistent way:
- the tears.* functions use 'long_short' and 'group_neutral' all around, as those functions are intended to be the top level ones. 'by_group' is used if the function support multiple plots output, one for each group
- the remaining API (mostry performance.*) use 'demeaned' and  'group_adjust' as they used to be