### PR TITLE
DOC: updated installation instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,14 @@ the factor tear sheet.
 Installation
 ------------
 
+Stable release
+
+::
+
+    pip install alphalens
+
+Development code
+
 ::
 
     pip install git+https://github.com/quantopian/alphalens


### PR DESCRIPTION
@twiecki  As agreed [here](https://github.com/quantopian/alphalens/pull/198) the preferred way to install Alphalens is now from pypi instead of gitub