### PR TITLE
max_loss increased to 25% by default

### DIFF
--- a/alphalens/tests/test_tears.py
+++ b/alphalens/tests/test_tears.py
@@ -75,8 +75,8 @@ class PerformanceTestCase(TestCase):
             self.prices,
             quantiles=quantiles,
             periods=periods,
-            filter_zscore=filter_zscore,
-            max_loss=0.15)
+            filter_zscore=filter_zscore)
+
         create_returns_tear_sheet(
             factor_data, long_short=long_short, by_group=False)
 
@@ -94,8 +94,8 @@ class PerformanceTestCase(TestCase):
             self.prices,
             quantiles=quantiles,
             periods=periods,
-            filter_zscore=filter_zscore,
-            max_loss=0.15)
+            filter_zscore=filter_zscore)
+
         create_information_tear_sheet(
             factor_data, group_adjust=False, by_group=False)
 
@@ -117,8 +117,8 @@ class PerformanceTestCase(TestCase):
             self.prices,
             quantiles=quantiles,
             periods=periods,
-            filter_zscore=filter_zscore,
-            max_loss=0.15)
+            filter_zscore=filter_zscore)
+
         create_turnover_tear_sheet(factor_data)
 
     @parameterized.expand([(2, (1, 5, 10), False, False),
@@ -139,8 +139,8 @@ class PerformanceTestCase(TestCase):
             self.prices,
             quantiles=quantiles,
             periods=periods,
-            filter_zscore=filter_zscore,
-            max_loss=0.15)
+            filter_zscore=filter_zscore)
+
         create_summary_tear_sheet(factor_data, long_short=long_short)
 
     @parameterized.expand([(2, (1, 5, 10), False, False),
@@ -161,8 +161,7 @@ class PerformanceTestCase(TestCase):
             self.prices,
             quantiles=quantiles,
             periods=periods,
-            filter_zscore=filter_zscore,
-            max_loss=0.15)
+            filter_zscore=filter_zscore)
 
         create_full_tear_sheet(
             factor_data,
@@ -184,8 +183,7 @@ class PerformanceTestCase(TestCase):
             self.prices,
             quantiles=quantiles,
             periods=periods,
-            filter_zscore=filter_zscore,
-            max_loss=0.20)
+            filter_zscore=filter_zscore)
 
         create_event_returns_tear_sheet(factor_data, self.prices, avgretplot=(
             5, 11), long_short=long_short, by_group=False)
@@ -235,7 +233,7 @@ class PerformanceTestCase(TestCase):
 
         factor_data = get_clean_factor_and_forward_returns(
             factor, self.prices, bins=1, quantiles=None, periods=(
-                1, 2), filter_zscore=filter_zscore, max_loss=0.10)
+                1, 2), filter_zscore=filter_zscore)
 
         create_event_study_tear_sheet(
             factor_data, self.prices, avgretplot=avgretplot)


### PR DESCRIPTION
Don't be too strict with max_loss default value, that would be frustrating. So print the amount of dropped factor data even when the limit is not reached, so that the user is aware of what happened. 

Also the code is nicer now, the Exceptions that are suppressed by utils.quantize_factor can be now seen setting max_loss=0 so that troubleshooting potential issues is still possible.