### PR TITLE
Update IC Risk Adjusted Ratio Calculation

### DIFF
--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -170,8 +170,8 @@ def plot_information_table(ic_data):
     ic_summary_table["p-value(IC)"] = p_value
     ic_summary_table["IC Skew"] = stats.skew(ic_data)
     ic_summary_table["IC Kurtosis"] = stats.kurtosis(ic_data)
-    ic_summary_table["Ann. IR"] = \
-        (ic_data.mean() / ic_data.std()) * np.sqrt(252)
+    ic_summary_table["Risk-Adjusted IC"] = \
+        ic_data.mean() / ic_data.std()
 
     print("Information Analysis")
     utils.print_table(ic_summary_table.apply(lambda x: x.round(3)).T)

--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -173,7 +173,6 @@ def plot_information_table(ic_data):
     ic_summary_table["IC Skew"] = stats.skew(ic_data)
     ic_summary_table["IC Kurtosis"] = stats.kurtosis(ic_data)
 
-
     print("Information Analysis")
     utils.print_table(ic_summary_table.apply(lambda x: x.round(3)).T)
 

--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -165,13 +165,14 @@ def plot_information_table(ic_data):
     ic_summary_table = pd.DataFrame()
     ic_summary_table["IC Mean"] = ic_data.mean()
     ic_summary_table["IC Std."] = ic_data.std()
+    ic_summary_table["Risk-Adjusted IC"] = \
+        ic_data.mean() / ic_data.std()
     t_stat, p_value = stats.ttest_1samp(ic_data, 0)
     ic_summary_table["t-stat(IC)"] = t_stat
     ic_summary_table["p-value(IC)"] = p_value
     ic_summary_table["IC Skew"] = stats.skew(ic_data)
     ic_summary_table["IC Kurtosis"] = stats.kurtosis(ic_data)
-    ic_summary_table["Risk-Adjusted IC"] = \
-        ic_data.mean() / ic_data.std()
+
 
     print("Information Analysis")
     utils.print_table(ic_summary_table.apply(lambda x: x.round(3)).T)

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -631,6 +631,18 @@ def std_conversion(period_std):
 def std_conversion(period_std):
     """
     1-period standard deviation (or standard error) approximation
+    
+    Parameters
+    ----------
+    period_std: pd.DataFrame
+        DataFrame containing standard deviation or standard error values
+        with column headings representing the return period.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame in same format as input but with one-period
+        standard deviation/error values.
     """
     period_len = period_std.name
     return period_std / np.sqrt(period_len)

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -628,5 +628,13 @@ def std_conversion(period_std):
     return period_std / np.sqrt(period_len)
 
 
+def std_conversion(period_std):
+    """
+    1-period standard deviation (or standard error) approximation
+    """
+    period_len = period_std.name
+    return period_std / np.sqrt(period_len)
+
+
 def get_forward_returns_columns(columns):
     return columns[columns.astype('str').str.isdigit()]

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -648,5 +648,13 @@ def std_conversion(period_std):
     return period_std / np.sqrt(period_len)
 
 
+def std_conversion(period_std):
+    """
+    1-period standard deviation (or standard error) approximation
+    """
+    period_len = period_std.name
+    return period_std / np.sqrt(period_len)
+
+
 def get_forward_returns_columns(columns):
     return columns[columns.astype('str').str.isdigit()]

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -628,25 +628,5 @@ def std_conversion(period_std):
     return period_std / np.sqrt(period_len)
 
 
-def std_conversion(period_std):
-    """
-    1-period standard deviation (or standard error) approximation
-    
-    Parameters
-    ----------
-    period_std: pd.DataFrame
-        DataFrame containing standard deviation or standard error values
-        with column headings representing the return period.
-
-    Returns
-    -------
-    pd.DataFrame
-        DataFrame in same format as input but with one-period
-        standard deviation/error values.
-    """
-    period_len = period_std.name
-    return period_std / np.sqrt(period_len)
-
-
 def get_forward_returns_columns(columns):
     return columns[columns.astype('str').str.isdigit()]

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -648,13 +648,5 @@ def std_conversion(period_std):
     return period_std / np.sqrt(period_len)
 
 
-def std_conversion(period_std):
-    """
-    1-period standard deviation (or standard error) approximation
-    """
-    period_len = period_std.name
-    return period_std / np.sqrt(period_len)
-
-
 def get_forward_returns_columns(columns):
     return columns[columns.astype('str').str.isdigit()]


### PR DESCRIPTION
In response to issue #208 , this modifies and renames risk-adjusted IC calculation. I also moved this "Risk-Adjusted IC" to immediately follow the "IC Mean" and "IC Std." fields. This seems to be more logical especially since the "t-stat (IC)" field immediately follows, which I believe is simply the risk-adjusted IC times the square root of the number of periods.

