### PR TITLE
Revert "Removed group_adjust/group_neutral flags from information analysis API"

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -24,6 +24,7 @@ from . import utils
 
 
 def factor_information_coefficient(factor_data,
+                                   group_adjust=False,
                                    by_group=False):
     """
     Computes the Spearman Rank Correlation based Information Coefficient (IC)
@@ -38,6 +39,8 @@ def factor_information_coefficient(factor_data,
         each period, the factor quantile/bin that factor value belongs to, and
         (optionally) the group the asset belongs to.
         - See full explanation in utils.get_clean_factor_and_forward_returns
+    group_adjust : bool
+        Demean forward returns by group before computing IC.
     by_group : bool
         If True, compute period wise IC separately for each group.
 
@@ -58,6 +61,9 @@ def factor_information_coefficient(factor_data,
 
     grouper = [factor_data.index.get_level_values('date')]
 
+    if group_adjust:
+        factor_data = utils.demean_forward_returns(factor_data,
+                                                   grouper + ['group'])
     if by_group:
         grouper.append('group')
 
@@ -68,6 +74,7 @@ def factor_information_coefficient(factor_data,
 
 
 def mean_information_coefficient(factor_data,
+                                 group_adjust=False,
                                  by_group=False,
                                  by_time=None):
     """
@@ -85,6 +92,8 @@ def mean_information_coefficient(factor_data,
         each period, the factor quantile/bin that factor value belongs to, and
         (optionally) the group the asset belongs to.
         - See full explanation in utils.get_clean_factor_and_forward_returns
+    group_adjust : bool
+        Demean forward returns by group before computing IC.
     by_group : bool
         If True, take the mean IC for each group.
     by_time : str (pd time_rule), optional
@@ -99,7 +108,7 @@ def mean_information_coefficient(factor_data,
         forward price movement windows.
     """
 
-    ic = factor_information_coefficient(factor_data, by_group)
+    ic = factor_information_coefficient(factor_data, group_adjust, by_group)
 
     grouper = []
     if by_time is not None:

--- a/alphalens/tests/test_performance.py
+++ b/alphalens/tests/test_performance.py
@@ -57,17 +57,23 @@ class PerformanceTestCase(TestCase):
                                   dtype="category")
 
     @parameterized.expand([(factor_data, [4, 3, 2, 1, 1, 2, 3, 4],
-                            False,
+                            False, False,
                             dr,
                             [-1., -1.],
                             ),
                            (factor_data, [1, 2, 3, 4, 4, 3, 2, 1],
-                            False,
+                            False, False,
                             dr,
                             [1., 1.],
                             ),
                            (factor_data, [1, 2, 3, 4, 4, 3, 2, 1],
-                            True,
+                            False, True,
+                            MultiIndex.from_product(
+                                [dr, [1, 2]], names=['date', 'group']),
+                            [1., 1., 1., 1.],
+                            ),
+                           (factor_data, [1, 2, 3, 4, 4, 3, 2, 1],
+                            True, True,
                             MultiIndex.from_product(
                                 [dr, [1, 2]], names=['date', 'group']),
                             [1., 1., 1., 1.],
@@ -75,6 +81,7 @@ class PerformanceTestCase(TestCase):
     def test_information_coefficient(self,
                                      factor_data,
                                      forward_returns,
+                                     group_adjust,
                                      by_group,
                                      expected_ix,
                                      expected_ic_val):
@@ -83,6 +90,7 @@ class PerformanceTestCase(TestCase):
                                 data=forward_returns)
 
         ic = factor_information_coefficient(factor_data=factor_data,
+                                            group_adjust=group_adjust,
                                             by_group=by_group)
 
         expected_ic_df = DataFrame(index=expected_ix,
@@ -94,11 +102,13 @@ class PerformanceTestCase(TestCase):
     @parameterized.expand([(factor_data,
                             [4, 3, 2, 1, 1, 2, 3, 4],
                             False,
+                            False,
                             'D',
                             dr,
                             [-1., -1.]),
                            (factor_data,
                             [1, 2, 3, 4, 4, 3, 2, 1],
+                            False,
                             False,
                             'W',
                             DatetimeIndex(['2015-01-04'],
@@ -107,12 +117,14 @@ class PerformanceTestCase(TestCase):
                             [1.]),
                            (factor_data,
                             [1, 2, 3, 4, 4, 3, 2, 1],
+                            False,
                             True,
                             None,
                             Int64Index([1, 2], name='group'),
                             [1., 1.]),
                            (factor_data,
                             [1, 2, 3, 4, 4, 3, 2, 1],
+                            False,
                             True,
                             'W',
                             MultiIndex.from_product(
@@ -124,6 +136,7 @@ class PerformanceTestCase(TestCase):
     def test_mean_information_coefficient(self,
                                           factor_data,
                                           forward_returns,
+                                          group_adjust,
                                           by_group,
                                           by_time,
                                           expected_ix,
@@ -133,6 +146,7 @@ class PerformanceTestCase(TestCase):
                                 data=forward_returns)
 
         ic = mean_information_coefficient(factor_data,
+                                          group_adjust=group_adjust,
                                           by_group=by_group,
                                           by_time=by_time)
 

--- a/alphalens/tests/test_tears.py
+++ b/alphalens/tests/test_tears.py
@@ -92,7 +92,8 @@ class PerformanceTestCase(TestCase):
             periods=periods,
             filter_zscore=filter_zscore)
 
-        create_information_tear_sheet(factor_data, by_group=False)
+        create_information_tear_sheet(
+            factor_data, group_neutral=False, by_group=False)
 
     @parameterized.expand([(2, (2, 3, 6), True),
                            (4, (1, 2, 3, 7), False)])


### PR DESCRIPTION
This reverts commit [2eed75589acf32cfcf87d93f86c9a55bf85cc1d8](https://github.com/quantopian/alphalens/commit/2eed75589acf32cfcf87d93f86c9a55bf85cc1d8).

The original commit was a oversight (actually a mistake :). As the flag was used to perform returns demeaning at group level before computing the IC between factor values and returns, the idea behind the commit was that subtracting a constant (the mean value) from the returns didn't affect the IC computation (IC is Spearman's rank correlation coefficient),
Unfortunately, as the IC is computed both on the full factor and by group, the flag is actually needed. Even though it doesn't change the IC at group level it is still relevant when computing IC for the full factor as we are indeed removing different values from different stocks (the value depends on the stock group).

