### PR TITLE
Added LICENSE to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include alphalens/_version.py
+include LICENSE


### PR DESCRIPTION
We should include the LICENSE in the source code; we also need it to deploy on conda-forge.