### PR TITLE
STY: Modify grid setup to follow other tears functions

### DIFF
--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -916,7 +916,7 @@ def plot_events_distribution(events, num_bars=50, ax=None):
     return ax
 
 
-def plot_multi_factor_quantile_returns(mean_ret_by_quantile, ax=None):
+def plot_multi_factor_quantile_returns(mean_ret_by_quantile, period, ax=None):
     """
     Plots mean period wise returns for factor quantiles.
 
@@ -924,6 +924,10 @@ def plot_multi_factor_quantile_returns(mean_ret_by_quantile, ax=None):
     ----------
     mean_ret_by_q : pd.DataFrame
         DataFrame with quantiles, (group) and mean period wise return values.
+    period: pandas.Timedelta or string
+        Length of period for which the returns are computed (e.g. 1 day)
+        if 'period' is a string it must follow pandas.Timedelta constructor
+        format (e.g. '1 days', '1D', '30m', '3h', '1D1h', etc)
     ax : matplotlib.Axes, optional
         Axes upon which to plot.
 
@@ -931,29 +935,14 @@ def plot_multi_factor_quantile_returns(mean_ret_by_quantile, ax=None):
     -------
     ax : matplotlib.Axes
     """
-    return_cols = \
-        utils.get_forward_returns_columns(mean_ret_by_quantile.columns)
-
-    # Set max number of columns in the plot grid to 3
-    MAX_COLS = 3
-    num_plots = len(return_cols)
     if ax is None:
-        v_spaces = ((num_plots - 1) // MAX_COLS + 1)
-        fig, ax = plt.subplots(v_spaces, min(num_plots, MAX_COLS),
-                               figsize=(18, v_spaces * 6))
-        ax = ax.flatten()
+        fig, ax = plt.subplots(figsize=(6, 6))
 
-    for a, ret_period in zip(ax, return_cols):
-        sns.heatmap(mean_ret_by_quantile[ret_period].unstack(), annot=True,
-                    cmap="RdYlGn", ax=a, center=0)
-        a.set(title="Mean {} Returns".format(ret_period))
-    plt.tight_layout()
-
-    # Hide unused subplots
-    if num_plots < len(ax):
-        num_plots_to_hide = MAX_COLS - num_plots % MAX_COLS
-        for i in range(1, num_plots_to_hide + 1):
-            ax[-i].set_visible(False)
-
-    plt.show()
+        sns.heatmap(mean_ret_by_quantile[period].unstack(), annot=True,
+                    cmap="RdYlGn", ax=ax, center=0)
+        ax.set(title="Mean {} Returns".format(period))
+    else:
+        sns.heatmap(mean_ret_by_quantile[period].unstack(), annot=True,
+                    cmap="RdYlGn", ax=ax, center=0)
+        ax.set(title="Mean {} Returns".format(period))
 

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -792,7 +792,6 @@ def create_factors_interaction_tear_sheet(multi_factor_data):
         factor quantile/bin that factor value belongs to, and (optionally)
         the group the asset belongs to.
     """
-    # Generate Rolling Correlation plot of two factors
     mean_ret_by_quantile, _ = \
         perf.mean_return_by_quantile(multi_factor_data,
                                      by_date=False,
@@ -801,6 +800,17 @@ def create_factors_interaction_tear_sheet(multi_factor_data):
                                      group_adjust=False,
                                      factor_groupers=['factor_1_quantile',
                                                       'factor_2_quantile'])
+    MAX_COLS = 3
+    return_cols = \
+        utils.get_forward_returns_columns(mean_ret_by_quantile.columns)
+    num_plots = len(return_cols)
+    v_spaces = ((num_plots - 1) // MAX_COLS + 1)
 
-    plotting.plot_multi_factor_quantile_returns(mean_ret_by_quantile)
+    gf = GridFigure(v_spaces, min(num_plots, MAX_COLS))
 
+    for period in mean_ret_by_quantile:
+        plotting.plot_multi_factor_quantile_returns(mean_ret_by_quantile,
+                                                    period,
+                                                    gf.next_cell())
+    plt.show()
+    gf.close()

--- a/alphalens/tests/test_multi_factor.py
+++ b/alphalens/tests/test_multi_factor.py
@@ -65,6 +65,7 @@ class MultiFactorTestCase(TestCase):
 
     @parameterized.expand([(False, 2, (1, 5, 10), None),
                            (False, 3, (1, 2, 3, 7), 20),
+                           (False, 3, (1,), None),
                            (True, 2, (1, 5, 10), None)])
     def test_create_multi_factor_data(self,
                                       binning_by_group,


### PR DESCRIPTION
Simplified plotting.plot_multi_factor_quantile_returns and bused GridFigure class in tears API to follow other alphalens tears functions.