### PR TITLE
2 small fixes

### DIFF
--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -777,7 +777,7 @@ def plot_cumulative_returns_by_quantile(quantile_returns,
     ret_wide = quantile_returns.unstack('factor_quantile')
 
     cum_ret = ret_wide.apply(perf.cumulative_returns, period=period)
-    cum_ret = cum_ret.loc[:, ::-1]
+    cum_ret = cum_ret.loc[:, ::-1]  # we want negative quantiles as 'red'
 
     cum_ret.plot(lw=2, ax=ax, cmap=cm.coolwarm)
     ax.legend()
@@ -827,6 +827,7 @@ def plot_quantile_average_cumulative_return(avg_cumulative_returns,
     avg_cumulative_returns = avg_cumulative_returns.multiply(DECIMAL_TO_BPS)
     quantiles = len(avg_cumulative_returns.index.levels[0].unique())
     palette = [cm.coolwarm(i) for i in np.linspace(0, 1, quantiles)]
+    palette = palette[::-1]  # we want negative quantiles as 'red'
 
     if by_quantile:
 

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -211,6 +211,11 @@ def compute_forward_returns(factor_idx,
 
     factor_idx = factor_idx.intersection(prices.index)
 
+    if len(factor_idx) == 0:
+        raise ValueError("Factor and prices indices don't match: make sure "
+                         "they have the same convention in terms of datetimes "
+                         "and symbol-names")
+
     forward_returns = pd.DataFrame(index=pd.MultiIndex.from_product(
         [factor_idx, prices.columns], names=['date', 'asset']))
 


### PR DESCRIPTION
- ENH: use same quantiles colours in different plots 
Cumumlative Returns by Quantile  plot uses a different colour scheme for quantiles than Average Cumulative Returns by Quantile plot

- ENH: improve error message if prices and signals do not match
Issue #282