### PR TITLE
BUG: get_clean_factor crashes with malformed 'groupby' data 

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -966,6 +966,9 @@ def average_cumulative_return_by_quantile(factor_data,
             #
             avgcumret = g_fq.groupby(g_fq).apply(average_cumulative_return,
                                                  demean_by)
+            if len(avgcumret) == 0:
+                continue
+
             avgcumret['group'] = group
             avgcumret.set_index('group', append=True, inplace=True)
             returns_bygroup.append(avgcumret)

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -642,17 +642,20 @@ def get_clean_factor_and_forward_returns(factor,
 
     prices : pd.DataFrame
         A wide form Pandas DataFrame indexed by timestamp with assets
-        in the columns. It is important to pass the
-        correct pricing data in depending on what time of period your
-        signal was generated so to avoid lookahead bias, or
-        delayed calculations. Pricing data must span the factor
-        analysis time period plus an additional buffer window
-        that is greater than the maximum number of expected periods
-        in the forward returns calculations.
+        in the columns.
+        Pricing data must span the factor analysis time period plus an
+        additional buffer window that is greater than the maximum number
+        of expected periods in the forward returns calculations.
+        It is important to pass the correct pricing data in depending on
+        what time of period your signal was generated so to avoid lookahead
+        bias, or  delayed calculations.
         'Prices' must contain at least an entry for each timestamp/asset
-        combination in 'factor'. This entry must be the asset price
-        at the time the asset factor value is computed and it will be
-        considered the buy price for that asset at that timestamp.
+        combination in 'factor'. This entry should reflect the buy price
+        for the assets and usually it is the next available price after the
+        factor is computed but it can also be a later price if the factor is
+        meant to be traded later (e.g. if the factor is computed at market
+        open but traded 1 hour after market open the price information should
+        be 1 hour after market open).
         'Prices' must also contain entries for timestamps following each
         timestamp/asset combination in 'factor', as many more timestamps
         as the maximum value in 'periods'. The asset price after 'period'

--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -519,7 +519,7 @@ def get_clean_factor(factor,
                         list(diff)))
 
             sn = pd.Series(groupby_labels)
-            groupby = pd.Series(index=factor.index,
+            groupby = pd.Series(index=groupby.index,
                                 data=sn[groupby.values].values)
 
         merged_data['group'] = groupby.astype('category')


### PR DESCRIPTION
If 'groupby' data contains too many or missing values (grouby index is not the same as the factor index) then 'utils.get_clean_factor' and 'utils.get_clean_factor_and_forward_return' crash with meaningless error messages.

+ improved docstring for 'price' argument