### PR TITLE
BUG: monthly IC heatmap use red for positive IC

### DIFF
--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -698,7 +698,7 @@ def plot_monthly_ic_heatmap(mean_monthly_ic, ax=None):
             annot_kws={"size": 7},
             linewidths=0.01,
             linecolor='white',
-            cmap=cm.coolwarm,
+            cmap=cm.coolwarm_r,
             cbar=False,
             ax=a)
         a.set(ylabel='', xlabel='')


### PR DESCRIPTION
This commit makes the positive IC blue and negative IC red

This is a regression introduced when improved the color scheme for colorblindness