### PR TITLE
BUG: Calculate mean returns by date before mean return by quantile

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -650,7 +650,10 @@ def mean_return_by_quantile(factor_data,
     mean_ret = group_stats.T.xs('mean', level=1).T
 
     if not by_date:
-        group_stats = mean_ret.groupby(level='factor_quantile')\
+        grouper = [mean_ret.index.get_level_values('factor_quantile')]
+        if by_group:
+            grouper.append(mean_ret.index.get_level_values('group'))
+        group_stats = mean_ret.groupby(grouper)\
             .agg(['mean', 'std', 'count'])
         mean_ret = group_stats.T.xs('mean', level=1).T
 

--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -638,9 +638,7 @@ def mean_return_by_quantile(factor_data,
     else:
         factor_data = factor_data.copy()
 
-    grouper = ['factor_quantile']
-    if by_date:
-        grouper.append(factor_data.index.get_level_values('date'))
+    grouper = ['factor_quantile', factor_data.index.get_level_values('date')]
 
     if by_group:
         grouper.append('group')
@@ -650,6 +648,11 @@ def mean_return_by_quantile(factor_data,
         .agg(['mean', 'std', 'count'])
 
     mean_ret = group_stats.T.xs('mean', level=1).T
+
+    if not by_date:
+        group_stats = mean_ret.groupby(level='factor_quantile')\
+            .agg(['mean', 'std', 'count'])
+        mean_ret = group_stats.T.xs('mean', level=1).T
 
     std_error_ret = group_stats.T.xs('std', level=1).T \
         / np.sqrt(group_stats.T.xs('count', level=1).T)


### PR DESCRIPTION
Compute mean return by date. If by_date flag is false, then compute
and return the average of the daily mean returns (and also the
standard error of these daily mean returns).

Resolves: Issue #309