### PR TITLE
BUG: Fix date conversion in newer versions of pandas

### DIFF
--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -909,7 +909,9 @@ def diff_custom_calendar_timedeltas(start, end, freq):
 
     if weekmask is not None and holidays is not None:
         # we prefer this method as it is faster
-        actual_days = np.busday_count(start, end, weekmask, holidays)
+        actual_days = np.busday_count(np.array(start).astype('datetime64[D]'),
+                                      np.array(end).astype('datetime64[D]'),
+                                      weekmask, holidays)
     else:
         # default, it is slow
         actual_days = pd.date_range(start, end, freq=freq).shape[0] - 1


### PR DESCRIPTION
In tests using pandas version 20.3, there was an error
`TypeError: Iterator operand 0 dtype could not be cast from
dtype('<M8[us]') to dtype('<M8[D]') according to the rule 'safe'`

Resolves Issue Discovered in #313