### PR TITLE
ENH Speed up fwdret computation

### DIFF
--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -278,11 +278,8 @@ def compute_forward_returns(factor,
         #
         # build forward returns
         #
-        fwdret = (prices
-                  .pct_change(period)
-                  .shift(-period)
-                  .reindex(factor_dateindex)
-                  )
+        fwdret = prices.shift(-period) / prices - 1
+        fwdret = fwdret.reindex(factor_dateindex)
 
         if filter_zscore is not None:
             mask = abs(fwdret - fwdret.mean()) > (filter_zscore * fwdret.std())


### PR DESCRIPTION
By computing directly from prices rather than using `pct_change()`.