### PR TITLE
MAINT: code refactoring to make it compatible with pandas 0.23.4

### DIFF
--- a/alphalens/performance.py
+++ b/alphalens/performance.py
@@ -201,8 +201,6 @@ def factor_weights(factor_data,
     if group_adjust:
         weights = weights.groupby(level='date').apply(to_weights, False, False)
 
-    # preserve freq, which contains trading calendar information
-    weights.index.levels[0].freq = factor_data.index.levels[0].freq
     return weights
 
 
@@ -253,8 +251,6 @@ def factor_returns(factor_data,
     else:
         returns = weighted_returns.groupby(level='date').sum()
 
-    # preserve freq, which contains trading calendar information
-    returns.index.freq = factor_data.index.levels[0].freq
     return returns
 
 

--- a/alphalens/plotting.py
+++ b/alphalens/plotting.py
@@ -711,7 +711,7 @@ def plot_monthly_ic_heatmap(mean_monthly_ic, ax=None):
     return ax
 
 
-def plot_cumulative_returns(factor_returns, period, title=None, ax=None):
+def plot_cumulative_returns(factor_returns, period, freq, title=None, ax=None):
     """
     Plots the cumulative returns of the returns series passed in.
 
@@ -724,6 +724,11 @@ def plot_cumulative_returns(factor_returns, period, title=None, ax=None):
         Length of period for which the returns are computed (e.g. 1 day)
         if 'period' is a string it must follow pandas.Timedelta constructor
         format (e.g. '1 days', '1D', '30m', '3h', '1D1h', etc)
+    freq : pandas DateOffset
+        Used to specify a particular trading calendar e.g. BusinessDay or Day
+        Usually this is inferred from utils.infer_trading_calendar, which is
+        called by either get_clean_factor_and_forward_returns or
+        compute_forward_returns
     title: string, optional
         Custom title
     ax : matplotlib.Axes, optional
@@ -737,7 +742,7 @@ def plot_cumulative_returns(factor_returns, period, title=None, ax=None):
     if ax is None:
         f, ax = plt.subplots(1, 1, figsize=(18, 6))
 
-    factor_returns = perf.cumulative_returns(factor_returns, period)
+    factor_returns = perf.cumulative_returns(factor_returns, period, freq)
 
     factor_returns.plot(ax=ax, lw=3, color='forestgreen', alpha=0.6)
     ax.set(ylabel='Cumulative Returns',
@@ -751,6 +756,7 @@ def plot_cumulative_returns(factor_returns, period, title=None, ax=None):
 
 def plot_cumulative_returns_by_quantile(quantile_returns,
                                         period,
+                                        freq,
                                         ax=None):
     """
     Plots the cumulative returns of various factor quantiles.
@@ -763,6 +769,11 @@ def plot_cumulative_returns_by_quantile(quantile_returns,
         Length of period for which the returns are computed (e.g. 1 day)
         if 'period' is a string it must follow pandas.Timedelta constructor
         format (e.g. '1 days', '1D', '30m', '3h', '1D1h', etc)
+    freq : pandas DateOffset
+        Used to specify a particular trading calendar e.g. BusinessDay or Day
+        Usually this is inferred from utils.infer_trading_calendar, which is
+        called by either get_clean_factor_and_forward_returns or
+        compute_forward_returns
     ax : matplotlib.Axes, optional
         Axes upon which to plot.
 
@@ -776,7 +787,7 @@ def plot_cumulative_returns_by_quantile(quantile_returns,
 
     ret_wide = quantile_returns.unstack('factor_quantile')
 
-    cum_ret = ret_wide.apply(perf.cumulative_returns, period=period)
+    cum_ret = ret_wide.apply(perf.cumulative_returns, period=period, freq=freq)
     cum_ret = cum_ret.loc[:, ::-1]  # we want negative quantiles as 'red'
 
     cum_ret.plot(lw=2, ax=ax, cmap=cm.coolwarm)

--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -17,6 +17,7 @@
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import pandas as pd
+import warnings
 
 from . import plotting
 from . import performance as perf
@@ -249,6 +250,14 @@ def create_returns_tear_sheet(factor_data,
                                           ylim_percentiles=(1, 99),
                                           ax=gf.next_row())
 
+    trading_calendar = factor_data.index.levels[0].freq
+    if trading_calendar is None:
+        trading_calendar = pd.tseries.offsets.BDay()
+        warnings.warn(
+            "'freq' not set in factor_data index: assuming business day",
+            UserWarning
+        )
+
     for p in factor_returns:
 
         title = ('Factor Weighted '
@@ -256,14 +265,20 @@ def create_returns_tear_sheet(factor_data,
                  + ('Long/Short ' if long_short else '')
                  + "Portfolio Cumulative Return ({} Period)".format(p))
 
-        plotting.plot_cumulative_returns(factor_returns[p],
-                                         period=p,
-                                         title=title,
-                                         ax=gf.next_row())
+        plotting.plot_cumulative_returns(
+            factor_returns[p],
+            period=p,
+            freq=trading_calendar,
+            title=title,
+            ax=gf.next_row()
+        )
 
-        plotting.plot_cumulative_returns_by_quantile(mean_quant_ret_bydate[p],
-                                                     period=p,
-                                                     ax=gf.next_row())
+        plotting.plot_cumulative_returns_by_quantile(
+            mean_quant_ret_bydate[p],
+            period=p,
+            freq=trading_calendar,
+            ax=gf.next_row()
+        )
 
     ax_mean_quantile_returns_spread_ts = [gf.next_row()
                                           for x in range(fr_cols)]
@@ -665,11 +680,22 @@ def create_event_study_tear_sheet(factor_data,
                                           ylim_percentiles=(1, 99),
                                           ax=gf.next_row())
 
+    trading_calendar = factor_data.index.levels[0].freq
+    if trading_calendar is None:
+        trading_calendar = pd.tseries.offsets.BDay()
+        warnings.warn(
+            "'freq' not set in factor_data index: assuming business day",
+            UserWarning
+        )
+
     for p in factor_returns:
 
-        plotting.plot_cumulative_returns(factor_returns[p],
-                                         period=p,
-                                         ax=gf.next_row())
+        plotting.plot_cumulative_returns(
+            factor_returns[p],
+            period=p,
+            freq=trading_calendar,
+            ax=gf.next_row()
+        )
 
     plt.show()
     gf.close()

--- a/alphalens/tests/test_performance.py
+++ b/alphalens/tests/test_performance.py
@@ -747,9 +747,8 @@ class PerformanceTestCase(TestCase):
         period_len = Timedelta(period_len)
         index = date_range('1/1/1999', periods=len(returns), freq=ret_freq)
         returns = Series(returns, index=index)
-        returns.index.freq = ret_freq_class
 
-        cum_ret = cumulative_returns(returns, period_len)
+        cum_ret = cumulative_returns(returns, period_len, ret_freq_class)
 
         expected = Series(expected_vals, index=cum_ret.index)
 


### PR DESCRIPTION
Added `freq` argument to `plot.plot_cumulative_returns` and `plot.plot_cumulative_returns_by_quantile`, which allow to avoid settings the index frequency inside `perf.to_weights` and `perf.factor_returns` (which in turn causes pandas  0.23.4 to crash, see #319 )

Also this closes #319 