### PR TITLE
use warning replace error when some assets not in groupby in utils.get_clean_factor

### DIFF
--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -21,6 +21,8 @@ from IPython.display import display
 from pandas.tseries.offsets import CustomBusinessDay, Day, BusinessDay
 from scipy.stats import mode
 
+import warnings
+
 
 class NonMatchingTimezoneError(Exception):
     pass
@@ -568,9 +570,10 @@ def get_clean_factor(factor,
             diff = set(factor_copy.index.get_level_values(
                 'asset')) - set(groupby.keys())
             if len(diff) > 0:
-                raise KeyError(
-                    "Assets {} not in group mapping".format(
-                        list(diff)))
+                warnings.warn(
+                    "Assets {} ... not in group mapping".format(
+                        list(diff)[:5])
+                )
 
             ss = pd.Series(groupby)
             groupby = pd.Series(index=factor_copy.index,
@@ -578,7 +581,7 @@ def get_clean_factor(factor,
                                     'asset')].values)
 
         if groupby_labels is not None:
-            diff = set(groupby.values) - set(groupby_labels.keys())
+            diff = set(groupby.dropna().values) - set(groupby_labels.keys())
             if len(diff) > 0:
                 raise KeyError(
                     "groups {} not in passed group names".format(


### PR DESCRIPTION
**use warning replace error when some assets not in groupby**

the parameter `groupby` of function `utils.get_clean_factor_and_forward_returns` should contain all `assets` in `factor`
but sometimes there are some `assets` not in group. in this case `utils.get_clean_factor_and_forward_returns` will raise an error
```python3
KeyError: "Assets ['xxx'] not in group mapping"
```
under these circumstances, people who use `alphalens` have to stop and find out which asset is not in group mapping and find a way to avoid this error
Just like the following
```python3
price_index = pd.date_range(start='2015-1-10', end='2015-2-28')
price_index.name = 'date'
tickers = ['A', 'B', 'C', 'D', 'E', 'F']
data = [[1.0025**i, 1.005**i, 1.00**i, 0.995**i, 1.005**i, 1.00**i]
        for i in range(1, 51)]
prices = pd.DataFrame(index=price_index, columns=tickers, data=data)

tickers = ['A', 'B', 'C', 'D', 'E', 'F']
factor_index = pd.date_range(start='2015-1-15', end='2015-2-13')
factor_index.name = 'date'
factor = pd.DataFrame(index=factor_index, columns=tickers,
                   data=[[3, 4, 2, 1, 5, 6], [3, 6, 5, 1, 4, 2],
                         [3, 4, 2, 1, 5, 6], [3, 4, 2, 1, 6, 5],
                         [3, 4, 2, 1, 5, 6], [3, 4, 2, 1, 6, 5],
                         [3, 5, 6, 1, 4, 2], [3, 6, 5, 1, 4, 2],
                         [3, 4, 2, 1, 5, 6], [3, 4, 2, 1, 6, 5],
                         [3, 5, 6, 1, 4, 2], [3, 6, 5, 1, 4, 2],
                         [3, 5, 6, 1, 4, 2], [3, 6, 5, 1, 4, 2],
                         [3, 5, 6, 1, 4, 2], [3, 6, 5, 1, 4, 2],
                         [3, 5, 6, 1, 4, 2], [3, 6, 5, 1, 4, 2],
                         [3, 5, 6, 1, 4, 2], [3, 6, 5, 1, 4, 2],
                         [3, 4, 2, 1, 5, 6], [3, 4, 2, 1, 6, 5],
                         [3, 4, 2, 1, 5, 6], [3, 4, 2, 1, 6, 5],
                         [3, 4, 2, 1, 5, 6], [3, 4, 2, 1, 6, 5],
                         [3, 4, 2, 1, 5, 6], [3, 4, 2, 1, 6, 5],
                         [3, 6, 5, 1, 4, 2], [3, 6, 5, 1, 4, 2]]).stack()

factor_groups = {'A': 'Group1', 'B': 'Group2', 'C': 'Group1', 'D': 'Group2', 'E': 'Group1'}

utils.get_clean_factor_and_forward_returns(factor=factor, prices=prices, groupby=factor_groups)
```

There ar 6 `tickers`, but `factor_groups` just includes 5
when we use `get_clean_factor_and_forward_returns` it will raise an error
```python3
KeyError: "Assets ['F'] not in group mapping"
```
now use warning to replace error to continue compute

```python3
UserWarning: Assets ['F'] ... not in group mapping
```