### PR TITLE
WIP: Trying to fix Travis Failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no --append channels conda-forge
+  - conda config --set always_yes yes --set changeps1 no
+  - conda config --append channels conda-forge
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: python
 sudo: false
 
-python: 
+python:
   - 2.7
   - 3.5
   - 3.6
 
 env:
-  global:
-    - STATSMODELS=statsmodels
-  jobs:
-    - PANDAS_VERSION=0.18.1
-    - PANDAS_VERSION=0.19.2
-    - PANDAS_VERSION=0.20.3
+  - PANDAS_VERSION=0.18.1
+  - PANDAS_VERSION=0.19.2
+  - PANDAS_VERSION=0.20.3
 
 matrix:
   exclude:
@@ -27,8 +24,10 @@ before_install:
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
-  - if [[ "$PANDAS_VERSION" == "0.18.1" ]]; then
-      STATSMODELS="statsmodels==0.9.0"
+  - if [[ $PANDAS_VERSION == "0.18.1" ]]; then
+      STATSMODELS="statsmodels==0.9.0";
+    else
+      STATSMODELS="statsmodels";
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no
+  - conda config --set always_yes yes --set changeps1 no --append channels conda-forge
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ python:
   - 3.6
 
 env:
-  - PANDAS_VERSION=0.18.1
-  - PANDAS_VERSION=0.19.2
-  - PANDAS_VERSION=0.20.3
+  global:
+    - STATSMODELS=statsmodels
+  jobs:
+    - PANDAS_VERSION=0.18.1
+    - PANDAS_VERSION=0.19.2
+    - PANDAS_VERSION=0.20.3
 
 matrix:
   exclude:
@@ -24,6 +27,9 @@ before_install:
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
+  - if [[ "$PANDAS_VERSION" == "0.18.1" ]]; then
+      STATSMODELS="statsmodels==0.9.0"
+    fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
@@ -34,7 +40,7 @@ before_install:
   - cp alphalens/tests/matplotlibrc .
 
 install:
-  - conda create -q -n testenv --yes python=$TRAVIS_PYTHON_VERSION ipython flake8 numpy scipy nose matplotlib pandas=$PANDAS_VERSION statsmodels seaborn
+  - conda create -q -n testenv --yes python=$TRAVIS_PYTHON_VERSION ipython flake8 numpy scipy nose matplotlib pandas=$PANDAS_VERSION $STATSMODELS seaborn
   - source activate testenv
   - pip install parameterized
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda config --append channels conda-forge
+  - conda config --add channels conda-forge
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a


### PR DESCRIPTION
There's two issues that I see: one is that the latest version of statsmodels requires at least pandas 19, so our pandas 18 builds fail; second is that pandas 18 seems to no longer be on the main [anaconda channel](https://repo.anaconda.com/pkgs/main/linux-64/), so add [conda-forge](https://anaconda.org/conda-forge/pandas/files?sort=basename&sort_order=asc) to the channel list.