### PR TITLE
use MultiIndex.set_names for pandas 1.0

### DIFF
--- a/alphalens/utils.py
+++ b/alphalens/utils.py
@@ -337,8 +337,7 @@ def compute_forward_returns(factor,
     df = df[column_list]
 
     df.index.levels[0].freq = freq
-    df.index.levels[0].name = "date"
-    df.index.levels[1].name = "asset"
+    df.index.set_names(['date', 'asset'], inplace=True)
 
     return df
 


### PR DESCRIPTION
fix for https://github.com/quantopian/alphalens/issues/359 which is blocking `get_clean_factor_and_forward_returns` for pandas>=1.0