### PR TITLE
fix 'Index' object has no attribute 'get_values' bug

### DIFF
--- a/alphalens/tears.py
+++ b/alphalens/tears.py
@@ -429,9 +429,9 @@ def create_turnover_tear_sheet(factor_data, turnover_periods=None):
     """
 
     if turnover_periods is None:
-        input_periods = utils.get_forward_returns_columns(
+        input_periods = list(utils.get_forward_returns_columns(
             factor_data.columns, require_exact_day_multiple=True,
-        ).get_values()
+        ))
         turnover_periods = utils.timedelta_strings_to_integers(input_periods)
     else:
         turnover_periods = utils.timedelta_strings_to_integers(


### PR DESCRIPTION
When invoke the function `alphalens.tears.create_turnover_tear_sheetalphalens.tears.create_turnover_tear_sheet()` without allocating the param `turnover_period`, may cause the `AttributeError: 'Index' object has no attribute 'get_values'`.It is because the `utils.get_forward_returns_columns()` returns columns as an object of `Index` instead of `pd.Series`.Hence, `Index` object hasn't have function `get_values()`.